### PR TITLE
Add Direct Passthrough Users

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -144,9 +144,9 @@ class Bot {
       const colorIndex = (username.charCodeAt(0) + username.length) % NICK_COLORS.length;
       const coloredUsername = irc.colors.wrap(NICK_COLORS[colorIndex], username);
       let text = this.parseText(message);
-      
+
       // Don't add a username when it's a passthrough user
-      if(!this.isPassthroughUser(author)) {
+      if (!this.isPassthroughUser(author)) {
         if (this.isCommandMessage(text)) {
           const prelude = `Command sent from Discord by ${username}:`;
           this.ircClient.say(ircChannel, prelude);

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -142,12 +142,11 @@ class Bot {
       if (this.isCommandMessage(text)) {
         const prelude = `Command sent from Discord by ${username}:`;
         this.ircClient.say(ircChannel, prelude);
-        this.ircClient.say(ircChannel, text);
       } else {
         text = `<${coloredUsername}> ${text}`;
         logger.debug('Sending message to IRC', ircChannel, text);
-        this.ircClient.say(ircChannel, text);
       }
+      this.ircClient.say(ircChannel, text);
     }
   }
 

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -42,6 +42,8 @@ class Bot {
 
     this.invertedMapping = _.invert(this.channelMapping);
     this.autoSendCommands = options.autoSendCommands || [];
+    // User IDs in this list won't have a <user> prefix when sent to IRC.
+    this.passthroughUserIDs = options.passthroughUserIDs || [];
   }
 
   connect() {
@@ -124,6 +126,10 @@ class Bot {
     return this.commandCharacters.indexOf(message[0]) !== -1;
   }
 
+  isPassthroughUser(author) {
+    return this.passthroughUserIDs.indexOf(author.id) !== -1;
+  }
+
   sendToIRC(message) {
     const author = message.author;
     // Ignore messages sent by the bot itself:
@@ -138,13 +144,16 @@ class Bot {
       const colorIndex = (username.charCodeAt(0) + username.length) % NICK_COLORS.length;
       const coloredUsername = irc.colors.wrap(NICK_COLORS[colorIndex], username);
       let text = this.parseText(message);
-
-      if (this.isCommandMessage(text)) {
-        const prelude = `Command sent from Discord by ${username}:`;
-        this.ircClient.say(ircChannel, prelude);
-      } else {
-        text = `<${coloredUsername}> ${text}`;
-        logger.debug('Sending message to IRC', ircChannel, text);
+      
+      // Don't add a username when it's a passthrough user
+      if(!this.isPassthroughUser(author)) {
+        if (this.isCommandMessage(text)) {
+          const prelude = `Command sent from Discord by ${username}:`;
+          this.ircClient.say(ircChannel, prelude);
+        } else {
+          text = `<${coloredUsername}> ${text}`;
+          logger.debug('Sending message to IRC', ircChannel, text);
+        }
       }
       this.ircClient.say(ircChannel, text);
     }


### PR DESCRIPTION
Being a rebel, I plan to see if I can use Discord-IRC to basically set up Discord as a personal, nice IRC client. In such a case, the <user> before every message becomes redundant and annoying. Since just ripping out that logic in a personal fork seemed like a bad idea (what if someone else *does* happen to connect and type something? I don't want to be impersonated!) I made this instead.

Discord user IDs can be added to an optional "passthroughUserIDs" section of the configuration, and if that user sends a message, it just sends through the bot directly. No <username>, no "Command sent by X from Discord", they just talk through the bot. If it doesn't exist in the config, or the user ID isn't in it, it acts as usual.

While what I'm trying to do isn't the goal of the project, I thought this might happen to have its uses. This is definitely a very niche thing to have, but since it works I figured why not PR it. My apologies if this is too out there.

(I'm definitely not a node.js dev, so I might have missed an easier way to do this, though the `npm run lint` didn't output anything. Additional apologies if there's anything obviously off.)