### PR TITLE
Enabling multi-server support for Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Create a discord user and join the server you want to connect to IRC.
     "discordEmail": "user@mail.com",
     "discordPassword": "letmein123",
     "channelMapping": {
-      "#other-discord": "#new-irc-channel"
+      "DiscordServerName,#other-discord": "#new-irc-channel"
     }
   },
 
@@ -59,7 +59,7 @@ Create a discord user and join the server you want to connect to IRC.
       ["AUTH", "test", "password"]
     ],
     "channelMapping": { // Maps each Discord-channel to an IRC-channel, used to direct messages to the correct place
-      "#discord": "#irc channel-password" // Add channel keys after the channel name
+      "DiscordServerName,#discord": "#irc channel-password" // Add channel keys after the channel name
     },
     "ircOptions": { // Optional node-irc options
       "floodProtection": false, // On by default

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -129,7 +129,10 @@ class Bot {
     // Ignore messages sent by the bot itself:
     if (author.id === this.discord.user.id) return;
 
-    const channelName = `#${message.channel.name}`;
+    // Ignore PMs
+    if (!message.channel.server) return;
+    const channelName = `${message.channel.server.name},#${message.channel.name}`;
+
     const ircChannel = this.channelMapping[channelName];
 
     logger.debug('Channel Mapping', channelName, this.channelMapping[channelName]);
@@ -152,10 +155,12 @@ class Bot {
   }
 
   sendToDiscord(author, channel, text) {
-    const discordChannelName = this.invertedMapping[channel.toLowerCase()];
-    if (discordChannelName) {
+    const discordServerChannelName = this.invertedMapping[channel.toLowerCase()];
+    if (discordServerChannelName) {
       // #channel -> channel before retrieving:
-      const discordChannel = this.discord.channels.get('name', discordChannelName.slice(1));
+      const discordServerName = discordServerChannelName.split(',')[0];
+      const discordChannelName = discordServerChannelName.split(',')[1].toLowerCase();
+      const discordChannel = this.discord.servers.get('name', discordServerName).channels.get('name', discordChannelName.slice(1));
 
       if (!discordChannel) {
         logger.info('Tried to send a message to a channel the bot isn\'t in: ',


### PR DESCRIPTION
configure channel mapping such as,
"channelMapping": {
   "DiscordServerName,#other-discord": "#new-irc-channel"
}

I haven't fixed all of the tests, still learning, but want to give you a pull request now for the actual implementation patch
