### PR TITLE
Discord attachment handling

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -143,6 +143,10 @@ class Bot {
         const prelude = `Command sent from Discord by ${username}:`;
         this.ircClient.say(ircChannel, prelude);
         this.ircClient.say(ircChannel, text);
+      } else if (typeof message.attachments[0] != 'undefined')	{			// Say the URL of an attachment (discord only permits one per message)
+        	 		var attachment = message.attachments[0];
+        	 		text = coloredUsername + ' posted an attachment: ' + attachment.url;		
+        	 		this.ircClient.say(ircChannel, text);
       } else {
         text = `<${coloredUsername}> ${text}`;
         logger.debug('Sending message to IRC', ircChannel, text);


### PR DESCRIPTION
Says the link of any discord attachment in IRC as a URL. Resolves issue #14.