### PR TITLE
Fix sending attachments to IRC

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -148,9 +148,11 @@ class Bot {
         this.ircClient.say(ircChannel, prelude);
         this.ircClient.say(ircChannel, text);
       } else {
-        text = `<${displayUsername}> ${text}`;
-        logger.debug('Sending message to IRC', ircChannel, text);
-        this.ircClient.say(ircChannel, text);
+        if (text !== '') {
+          text = `<${displayUsername}> ${text}`;
+          logger.debug('Sending message to IRC', ircChannel, text);
+          this.ircClient.say(ircChannel, text);
+        }
 
         if (message.attachments && message.attachments.length) {
           message.attachments.forEach(a => {

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -147,17 +147,19 @@ class Bot {
         const prelude = `Command sent from Discord by ${username}:`;
         this.ircClient.say(ircChannel, prelude);
         this.ircClient.say(ircChannel, text);
-      } else if (message.attachments && message.attachments.length) {
-        message.attachments.forEach(a => {
-          const urlMessage =
-            `${displayUsername} posted an attachment to ${channelName} on Discord: ${a.url}`;
-          logger.debug('Sending attachment URL to IRC', ircChannel, urlMessage);
-          this.ircClient.say(ircChannel, urlMessage);
-        });
       } else {
         text = `<${displayUsername}> ${text}`;
         logger.debug('Sending message to IRC', ircChannel, text);
         this.ircClient.say(ircChannel, text);
+
+        if (message.attachments && message.attachments.length) {
+          message.attachments.forEach(a => {
+            const urlMessage =
+              `${displayUsername} posted an attachment to ${channelName} on Discord: ${a.url}`;
+            logger.debug('Sending attachment URL to IRC', ircChannel, urlMessage);
+            this.ircClient.say(ircChannel, urlMessage);
+          });
+        }
       }
     }
   }

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -156,8 +156,7 @@ class Bot {
 
         if (message.attachments && message.attachments.length) {
           message.attachments.forEach(a => {
-            const urlMessage =
-              `${displayUsername} posted an attachment to ${channelName} on Discord: ${a.url}`;
+            const urlMessage = `<${displayUsername}> ${a.url}`;
             logger.debug('Sending attachment URL to IRC', ircChannel, urlMessage);
             this.ircClient.say(ircChannel, urlMessage);
           });

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -131,6 +131,34 @@ describe('Bot', function() {
     ClientStub.prototype.say.should.have.been.calledWith('#irc', expected);
   });
 
+  it('should send text message and attachment URL to IRC if both exist', function() {
+    const text = 'Look at this cute cat picture!';
+    const attachmentUrl = 'https://image/url.jpg';
+    const message = {
+      content: text,
+      attachments: [{
+        url: attachmentUrl
+      }],
+      mentions: [],
+      channel: {
+        name: 'discord'
+      },
+      author: {
+        username: 'otherauthor',
+        id: 'not bot id'
+      }
+    };
+
+    this.bot.sendToIRC(message);
+
+    ClientStub.prototype.say.should.have.been.calledWith('#irc',
+      `<\u000304${message.author.username}\u000f> ${text}`);
+
+    const expected = `\u000304${message.author.username}\u000f posted an attachment to ` +
+      `#${message.channel.name} on Discord: ${attachmentUrl}`;
+    ClientStub.prototype.say.should.have.been.calledWith('#irc', expected);
+  });
+
   it('should not send its own messages to irc', function() {
     const message = {
       author: {

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -159,6 +159,27 @@ describe('Bot', function() {
     ClientStub.prototype.say.should.have.been.calledWith('#irc', expected);
   });
 
+  it('should not send an empty text message with an attachment to IRC', function() {
+    const message = {
+      content: '',
+      attachments: [{
+        url: 'https://image/url.jpg'
+      }],
+      mentions: [],
+      channel: {
+        name: 'discord'
+      },
+      author: {
+        username: 'otherauthor',
+        id: 'not bot id'
+      }
+    };
+
+    this.bot.sendToIRC(message);
+
+    ClientStub.prototype.say.should.have.been.calledOnce;
+  });
+
   it('should not send its own messages to irc', function() {
     const message = {
       author: {

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -125,9 +125,7 @@ describe('Bot', function() {
     };
 
     this.bot.sendToIRC(message);
-    // Wrap in colors:
-    const expected = `\u000304${message.author.username}\u000f posted an attachment to ` +
-      `#${message.channel.name} on Discord: ${attachmentUrl}`;
+    const expected = `<\u000304${message.author.username}\u000f> ${attachmentUrl}`;
     ClientStub.prototype.say.should.have.been.calledWith('#irc', expected);
   });
 
@@ -154,8 +152,7 @@ describe('Bot', function() {
     ClientStub.prototype.say.should.have.been.calledWith('#irc',
       `<\u000304${message.author.username}\u000f> ${text}`);
 
-    const expected = `\u000304${message.author.username}\u000f posted an attachment to ` +
-      `#${message.channel.name} on Discord: ${attachmentUrl}`;
+    const expected = `<\u000304${message.author.username}\u000f> ${attachmentUrl}`;
     ClientStub.prototype.say.should.have.been.calledWith('#irc', expected);
   });
 


### PR DESCRIPTION
Now that Discord actually got the ability to send both text messages and attachments in single message, here's the code to support that.

This time with tests right off the bat!