### PR TITLE
Add options to configure Discord messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ Create a discord user and join the server you want to connect to IRC.
     "channelMapping": { // Maps each Discord-channel to an IRC-channel, used to direct messages to the correct place
       "#discord": "#irc channel-password" // Add channel keys after the channel name
     },
+    "discordOptions": { // Optional Discord message options
+      "includeAuthor": false // On by default
+    },
     "ircOptions": { // Optional node-irc options
       "floodProtection": false, // On by default
       "floodProtectionDelay": 1000 // 500 by default

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -28,6 +28,7 @@ class Bot {
     this.server = options.server;
     this.nickname = options.nickname;
     this.ircOptions = options.ircOptions;
+    this.discordOptions = options.discordOptions;
     this.discordEmail = options.discordEmail;
     this.discordPassword = options.discordPassword;
     this.commandCharacters = options.commandCharacters || [];
@@ -178,16 +179,31 @@ class Bot {
         return;
       }
 
-      const withMentions = text.replace(/@[^\s]+\b/g, match => {
-        const user = this.discord.users.get('username', match.substring(1));
-        return user ? user.mention() : match;
-      });
+      const message = this.formatDiscordMessage(author, text);
 
-      // Add bold formatting:
-      const withAuthor = `**<${author}>** ${withMentions}`;
-      logger.debug('Sending message to Discord', withAuthor, channel, '->', discordChannelName);
-      this.discord.sendMessage(discordChannel, withAuthor);
+      logger.debug('Sending message to Discord', message, channel, '->', discordChannelName);
+      this.discord.sendMessage(discordChannel, message);
     }
+  }
+
+  formatDiscordMessage(author, text) {
+    const discordOptions = {
+      includeAuthor: true,
+      ...this.discordOptions
+    };
+
+    // update user mentions
+    let message = text.replace(/@[^\s]+\b/g, match => {
+      const user = this.discord.users.get('username', match.substring(1));
+      return user ? user.mention() : match;
+    });
+
+    // prepend the author name with bold formatting
+    if (discordOptions.includeAuthor) {
+      message = `**<${author}>** ${message}`;
+    }
+
+    return message;
   }
 }
 

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -51,6 +51,21 @@ describe('Bot', function() {
     DiscordStub.prototype.sendMessage.should.have.been.calledWith(discordChannel, formatted);
   });
 
+  it('should apply discordOptions formatting when sending messages to discord', function() {
+    const configWithDiscordOptions = {
+      ...config,
+      discordOptions: {
+        includeAuthor: false
+      }
+    };
+    this.bot = new Bot(configWithDiscordOptions);
+    this.bot.connect();
+    const username = 'testuser';
+    const text = 'test message';
+    this.bot.sendToDiscord(username, '#irc', text);
+    DiscordStub.prototype.sendMessage.should.have.been.calledWith(discordChannel, text);
+  });
+
   it('should lowercase channel names before sending to discord', function() {
     const username = 'testuser';
     const text = 'test message';


### PR DESCRIPTION
This allows `**<author>**` to be configurable when sending a message from IRC to Discord.

A `discordOptions` object is added to the config with an `includeAuthor` property. This is enabled by default, so there are no BC changes, it just allows for it to be excluded.

As for the implementation, I moved the formatting implementation details into a new `formatDiscordMessage` function since there is additional logic, and the potential for further rules to become applied.

----

I want to use `discord-irc` to allow myself to use Discord _as a user_ through IRC. Rather than having the IRC chat be a proxy for many users, through the Discord bot user, I want to treat it more as a direct proxy for _my_ Discord account. 

All I need is for messages from IRC to omit the author tag and I'm good to go!


### Example

- `atticus-test` is "another user in the Discord chat"
- `atticus` is me, both my Discord user, and the person chatting through IRC. 

![screen shot 2016-04-21 at 12 02 21 am](https://cloud.githubusercontent.com/assets/656630/14697699/57863ac2-0754-11e6-9fda-387f24479c46.png)

![screen shot 2016-04-21 at 12 00 55 am](https://cloud.githubusercontent.com/assets/656630/14697693/42f429ac-0754-11e6-86e7-a149dbf35efc.png)
