### PR TITLE
Fix pings to users with nicknames showing as raw user IDs in IRC

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -111,6 +111,7 @@ class Bot {
   parseText(message) {
     const text = message.mentions.reduce((content, mention) => (
       content.replace(`<@${mention.id}>`, `@${mention.username}`)
+             .replace(`<@!${mention.id}>`, `@${mention.username}`)
     ), message.content);
 
     return text

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -238,6 +238,18 @@ describe('Bot', function() {
     this.bot.parseText(message).should.equal('@testuser hi');
   });
 
+  it('should convert user nickname mentions from discord', function() {
+    const message = {
+      mentions: [{
+        id: 123,
+        username: 'testuser'
+      }],
+      content: '<@!123> hi'
+    };
+
+    this.bot.parseText(message).should.equal('@testuser hi');
+  });
+
   it('should convert user mentions from IRC', function() {
     const testuser = new discord.User({ username: 'testuser', id: '123' }, this.bot.discord);
     this.bot.discord.users.get.withArgs('username', testuser.username).returns(testuser);


### PR DESCRIPTION
before: `<GinjaNinja32> <@!169859930382270465>`
after: `<GinjaNinja32> @GinjaNinja32`

Both of these show as `@Ginja` on the Discord side; given discord-irc already ignores nicknames for the user that's shown on IRC, I decided against replacing the user's nickname in instead for `<@! ... >` pings.