### PR TITLE
Added formatting conversions to messages

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -4,6 +4,7 @@ import logger from 'winston';
 import discord from 'discord.js';
 import { ConfigurationError } from './errors';
 import { validateChannelMapping } from './validators';
+import { formatFromDiscordToIRC, formatFromIRCToDiscord } from './formatting';
 
 const REQUIRED_FIELDS = ['server', 'nickname', 'channelMapping', 'discordToken'];
 const NICK_COLORS = ['light_blue', 'dark_blue', 'light_red', 'dark_red', 'light_green',
@@ -150,6 +151,9 @@ class Bot {
         this.ircClient.say(ircChannel, text);
       } else {
         if (text !== '') {
+          // Convert formatting
+          text = formatFromDiscordToIRC(text);
+
           text = `<${displayUsername}> ${text}`;
           logger.debug('Sending message to IRC', ircChannel, text);
           this.ircClient.say(ircChannel, text);
@@ -178,7 +182,10 @@ class Bot {
         return;
       }
 
-      const withMentions = text.replace(/@[^\s]+\b/g, match => {
+      // Convert text formatting (bold, italics, underscore)
+      const withFormat = formatFromIRCToDiscord(text);
+
+      const withMentions = withFormat.replace(/@[^\s]+\b/g, match => {
         const user = this.discord.users.get('username', match.substring(1));
         return user ? user.mention() : match;
       });

--- a/lib/formatting.js
+++ b/lib/formatting.js
@@ -55,7 +55,7 @@ export function formatFromIRCToDiscord(text) {
   }
 
   // Remove all color markers from the message, as discord does not support colored text
-  resultString = resultString.replace(/\u0003(\d\d(,\d\d)?)?/g, '');
+  resultString = resultString.replace(/\u0003(\d\d?(,\d\d?)?)?/g, '');
 
   return resultString;
 }

--- a/lib/formatting.js
+++ b/lib/formatting.js
@@ -1,0 +1,58 @@
+/* eslint-disable no-unused-vars */
+
+export function formatFromDiscordToIRC(text) {
+  // Apply formatting rules, from most specific to least specific.
+  return text.replace(/~~(.*?)~~/g, '$1')                        // Remove unsupported strikethrough
+    .replace(/__\*\*\*(.*?)\*\*\*__/g, '\u001F\u001D\u0002$1\u000F') // Apply underline-italics-bold
+    .replace(/__\*\*(.*?)\*\*__/g, '\u001F\u0002$1\u000F')           // Apply underline-bold
+    .replace(/__\*(.*?)\*__/g, '\u001F\u001D$1\u000F')               // Apply underline-italics
+    .replace(/__(.*?)__/g, '\u001F$1\u000F')                         // Apply underline
+    .replace(/\*\*\*(.*?)\*\*\*/g, '\u0002\u001D$1\u000F')          // Apply bold-italics
+    .replace(/\*\*(.*?)\*\*/g, '\u0002$1\u000F')                     // Apply bold
+    .replace(/\*(.*?)\*/g, '\u001D$1\u000F');                        // Apply italics
+}
+
+export function formatFromIRCToDiscord(text) {
+  // Regex doesn't work here, because formatting can be applied arbitrarily in IRC.
+  // Iterate over the string, and keep track of which formatting is active,
+  // and close all formatting if a reset symbol is encountered.
+
+  const FORMATTERS = {
+    BOLD: 1,
+    ITALICS: 2,
+    UNDERLINE: 3,
+    discordSymbols: {
+      1: '**',
+      2: '*',
+      3: '__'
+    }
+  };
+
+  let activeFormatters = [];
+  let resultString = '';
+
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i];
+    if (char === '\u001D') { // italics
+      activeFormatters.push(FORMATTERS.ITALICS);
+      resultString = resultString.concat('*');
+    } else if (char === '\u0002') { // bold
+      activeFormatters.push(FORMATTERS.BOLD);
+      resultString = resultString.concat('**');
+    } else if (char === '\u001F') { // underline
+      activeFormatters.push(FORMATTERS.UNDERLINE);
+      resultString = resultString.concat('__');
+    } else if (char === '\u000F') { // reset
+      // Reset all active formattings
+      for (let j = (activeFormatters.length - 1); j >= 0; j--) {
+        resultString = resultString.concat(FORMATTERS.discordSymbols[activeFormatters[j]]);
+      }
+      activeFormatters = [];
+    } else {
+      // Add character
+      resultString = resultString.concat(char);
+    }
+  }
+
+  return resultString;
+}

--- a/lib/formatting.js
+++ b/lib/formatting.js
@@ -15,7 +15,7 @@ export function formatFromDiscordToIRC(text) {
 export function formatFromIRCToDiscord(text) {
   // Regex doesn't work here, because formatting can be applied arbitrarily in IRC.
   // Iterate over the string, and keep track of which formatting is active,
-  // and close all formatting if a reset symbol is encountered.
+  // and close all formatting in order if a reset symbol is encountered.
 
   const FORMATTERS = {
     BOLD: 1,
@@ -53,6 +53,9 @@ export function formatFromIRCToDiscord(text) {
       resultString = resultString.concat(char);
     }
   }
+
+  // Remove all color markers from the message, as discord does not support colored text
+  resultString = resultString.replace(/\u0003(\d\d(,\d\d)?)?/g, '');
 
   return resultString;
 }

--- a/test/formatting.test.js
+++ b/test/formatting.test.js
@@ -1,0 +1,26 @@
+/* eslint-disable prefer-arrow-callback */
+
+import chai from 'chai';
+import { formatFromDiscordToIRC, formatFromIRCToDiscord } from '../lib/formatting';
+
+const expect = chai.expect;
+
+describe('formatFromDiscordToIRC', function() {
+  it('should parse a discord string into an irc string', function() {
+    const result = formatFromDiscordToIRC('**Hello!** *This* ~~is~~ __*a*__ __**discord**__ ' +
+      '__string__ __***with***__ *some* ***formatting.***');
+    expect(result).to.equal('\u0002Hello!\u000F \u001DThis\u000F is \u001F\u001Da\u000F ' +
+      '\u001F\u0002discord\u000F \u001Fstring\u000F \u001F\u001D\u0002with\u000F ' +
+      '\u001Dsome\u000F \u0002\u001Dformatting.\u000F');
+  });
+});
+
+describe('formatFromIRCToDiscord', function() {
+  it('should parse an irc string into a discord string', function() {
+    const result = formatFromIRCToDiscord('\u0002Hello!\u000F \u001DThis\u000F is ' +
+      '\u001F\u001Da\u000F \u001F\u0002discord\u000F \u001Fstring\u000F ' +
+      '\u001F\u001D\u0002with\u000F \u001Dsome\u000F \u0002\u001Dformatting.\u000F');
+    expect(result).to.equal('**Hello!** *This* is __*a*__ __**discord**__ __string__ ' +
+      '__***with***__ *some* ***formatting.***');
+  });
+});

--- a/test/formatting.test.js
+++ b/test/formatting.test.js
@@ -5,7 +5,7 @@ import { formatFromDiscordToIRC, formatFromIRCToDiscord } from '../lib/formattin
 
 const expect = chai.expect;
 
-describe('formatFromDiscordToIRC', function() {
+describe('Formatting', function() {
   it('should parse a discord string into an irc string', function() {
     const result = formatFromDiscordToIRC('**Hello!** *This* ~~is~~ __*a*__ __**discord**__ ' +
       '__string__ __***with***__ *some* ***formatting.***');
@@ -13,13 +13,12 @@ describe('formatFromDiscordToIRC', function() {
       '\u001F\u0002discord\u000F \u001Fstring\u000F \u001F\u001D\u0002with\u000F ' +
       '\u001Dsome\u000F \u0002\u001Dformatting.\u000F');
   });
-});
 
-describe('formatFromIRCToDiscord', function() {
   it('should parse an irc string into a discord string', function() {
     const result = formatFromIRCToDiscord('\u0002Hello!\u000F \u001DThis\u000F is ' +
-      '\u001F\u001Da\u000F \u001F\u0002discord\u000F \u001Fstring\u000F ' +
-      '\u001F\u001D\u0002with\u000F \u001Dsome\u000F \u0002\u001Dformatting.\u000F');
+      '\u001F\u001Da\u000F \u001F\u0002discord\u000F \u001F\u000306string\u0003\u000F ' +
+      '\u001F\u001D\u0002with\u000F \u001D\u000304,01some\u0003\u000F ' +
+      '\u0002\u001Dformatting.\u000F');
     expect(result).to.equal('**Hello!** *This* is __*a*__ __**discord**__ __string__ ' +
       '__***with***__ *some* ***formatting.***');
   });


### PR DESCRIPTION
I added text formatting conversions to messages. Things like bold, italic and underscored text will be converted into their counterparts on the other service, and colors and strikethroughs will be stripped because they are unsupported on the other platform.

This would fix number 2 from issue #86 and issue #89.

### For example on discord:
![discord-irc_formatting1](https://cloud.githubusercontent.com/assets/1193988/17419215/b9a23c42-5a9c-11e6-8fe9-06675cdc9434.png)

### And on IRC:
![discord-irc_formatting2](https://cloud.githubusercontent.com/assets/1193988/17419216/bbe66ea6-5a9c-11e6-9625-b47f06417f1e.png)
