### PR TITLE
Send text messages only to text discord channels

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -170,8 +170,10 @@ class Bot {
   sendToDiscord(author, channel, text) {
     const discordChannelName = this.invertedMapping[channel.toLowerCase()];
     if (discordChannelName) {
-      // #channel -> channel before retrieving:
-      const discordChannel = this.discord.channels.find('name', discordChannelName.slice(1));
+      // #channel -> channel before retrieving and select only text channels:
+      const discordChannel = this.discord.channels
+        .filter(c => c.type === 'text')
+        .find('name', discordChannelName.slice(1));
 
       if (!discordChannel) {
         logger.info('Tried to send a message to a channel the bot isn\'t in: ',


### PR DESCRIPTION
This adds a function predicate for finding channels so that only text-channels are selected for text relay. Also adds a debug log in the case the select channel can't receive text messages.
