### PR TITLE
Avoid self-message highlights on IRC

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -162,9 +162,14 @@ class Bot {
       const nickname = Bot.getDiscordNicknameOnServer(author, fromGuild);
       let text = this.parseText(message);
       let displayUsername = nickname;
+
+      // Join the display name with double "bold" formatting characters
+      // to prevent unintentional highlights on the IRC side
+      displayUsername = displayUsername.split('').join('\u200d');
+
       if (this.ircNickColor) {
         const colorIndex = (nickname.charCodeAt(0) + nickname.length) % NICK_COLORS.length;
-        displayUsername = irc.colors.wrap(NICK_COLORS[colorIndex], nickname);
+        displayUsername = irc.colors.wrap(NICK_COLORS[colorIndex], displayUsername);
       }
 
       if (this.isCommandMessage(text)) {

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -98,7 +98,7 @@ describe('Bot', function () {
     };
 
     bot.sendToIRC(message);
-    const expected = `<${message.author.username}> ${text}`;
+    const expected = `<${message.author.username.split('').join('\u200d')}> ${text}`;
     ClientStub.prototype.say.should.have.been.calledWith('#irc', expected);
   });
 
@@ -120,7 +120,7 @@ describe('Bot', function () {
 
     this.bot.sendToIRC(message);
     // Wrap in colors:
-    const expected = `<\u000304${message.author.username}\u000f> ${text}`;
+    const expected = `<\u000304${message.author.username.split('').join('\u200d')}\u000f> ${text}`;
     ClientStub.prototype.say.should.have.been.calledWith('#irc', expected);
   });
 
@@ -142,7 +142,7 @@ describe('Bot', function () {
     };
 
     this.bot.sendToIRC(message);
-    const expected = `<\u000304${message.author.username}\u000f> ${attachmentUrl}`;
+    const expected = `<\u000304${message.author.username.split('').join('\u200d')}\u000f> ${attachmentUrl}`;
     ClientStub.prototype.say.should.have.been.calledWith('#irc', expected);
   });
 
@@ -167,9 +167,9 @@ describe('Bot', function () {
     this.bot.sendToIRC(message);
 
     ClientStub.prototype.say.should.have.been.calledWith('#irc',
-      `<\u000304${message.author.username}\u000f> ${text}`);
+      `<\u000304${message.author.username.split('').join('\u200d')}\u000f> ${text}`);
 
-    const expected = `<\u000304${message.author.username}\u000f> ${attachmentUrl}`;
+    const expected = `<\u000304${message.author.username.split('').join('\u200d')}\u000f> ${attachmentUrl}`;
     ClientStub.prototype.say.should.have.been.calledWith('#irc', expected);
   });
 
@@ -243,7 +243,7 @@ describe('Bot', function () {
     };
 
     // Wrap it in colors:
-    const expected = `<\u000312${message.author.username}\u000f> #${message.channel.name}`;
+    const expected = `<\u000312${message.author.username.split('').join('\u200d')}\u000f> #${message.channel.name}`;
     this.bot.sendToIRC(message);
     ClientStub.prototype.say
       .should.have.been.calledWith('#irc', expected);
@@ -382,7 +382,7 @@ describe('Bot', function () {
     };
 
     bot.sendToIRC(message);
-    const expected = `<${nickname}> ${text}`;
+    const expected = `<${nickname.split('').join('\u200d')}> ${text}`;
     ClientStub.prototype.say.should.have.been.calledWith('#irc', expected);
   });
 

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -10,6 +10,8 @@ import createDiscordStub from './stubs/discord-stub';
 import ClientStub from './stubs/irc-client-stub';
 import config from './fixtures/single-test-config.json';
 
+const escapeUsername = username => username.split('').join('\u200d');
+
 chai.should();
 chai.use(sinonChai);
 
@@ -98,7 +100,7 @@ describe('Bot', function () {
     };
 
     bot.sendToIRC(message);
-    const expected = `<${message.author.username.split('').join('\u200d')}> ${text}`;
+    const expected = `<${escapeUsername(message.author.username)}> ${text}`;
     ClientStub.prototype.say.should.have.been.calledWith('#irc', expected);
   });
 
@@ -120,7 +122,7 @@ describe('Bot', function () {
 
     this.bot.sendToIRC(message);
     // Wrap in colors:
-    const expected = `<\u000304${message.author.username.split('').join('\u200d')}\u000f> ${text}`;
+    const expected = `<\u000304${escapeUsername(message.author.username)}\u000f> ${text}`;
     ClientStub.prototype.say.should.have.been.calledWith('#irc', expected);
   });
 
@@ -142,7 +144,7 @@ describe('Bot', function () {
     };
 
     this.bot.sendToIRC(message);
-    const expected = `<\u000304${message.author.username.split('').join('\u200d')}\u000f> ${attachmentUrl}`;
+    const expected = `<\u000304${escapeUsername(message.author.username)}\u000f> ${attachmentUrl}`;
     ClientStub.prototype.say.should.have.been.calledWith('#irc', expected);
   });
 
@@ -167,9 +169,9 @@ describe('Bot', function () {
     this.bot.sendToIRC(message);
 
     ClientStub.prototype.say.should.have.been.calledWith('#irc',
-      `<\u000304${message.author.username.split('').join('\u200d')}\u000f> ${text}`);
+      `<\u000304${escapeUsername(message.author.username)}\u000f> ${text}`);
 
-    const expected = `<\u000304${message.author.username.split('').join('\u200d')}\u000f> ${attachmentUrl}`;
+    const expected = `<\u000304${escapeUsername(message.author.username)}\u000f> ${attachmentUrl}`;
     ClientStub.prototype.say.should.have.been.calledWith('#irc', expected);
   });
 
@@ -243,7 +245,7 @@ describe('Bot', function () {
     };
 
     // Wrap it in colors:
-    const expected = `<\u000312${message.author.username.split('').join('\u200d')}\u000f> #${message.channel.name}`;
+    const expected = `<\u000312${escapeUsername(message.author.username)}\u000f> #${message.channel.name}`;
     this.bot.sendToIRC(message);
     ClientStub.prototype.say
       .should.have.been.calledWith('#irc', expected);
@@ -382,7 +384,7 @@ describe('Bot', function () {
     };
 
     bot.sendToIRC(message);
-    const expected = `<${nickname.split('').join('\u200d')}> ${text}`;
+    const expected = `<${escapeUsername(nickname)}> ${text}`;
     ClientStub.prototype.say.should.have.been.calledWith('#irc', expected);
   });
 


### PR DESCRIPTION
When a user connected to both Discord and IRC speaks on Discord, they will likely get unwanted highlights in their IRC client.  This is a fix which I believe is standard practice.  By putting a zero width space character between each letter of the display name, we ensure IRC clients do not detect the name and highlight on it.

The other line in the commit is a fix where the wrong variable was being used.