### PR TITLE
Add the option to prevent the user who uses both Discord and IRC from being notified by messages they sent themself

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,11 @@ First you need to create a Discord bot user, which you can do by following the i
     "ircNickColor": false, // Gives usernames a color in IRC for better readability (on by default)
     // Makes the bot hide the username prefix for messages that start
     // with one of these characters (commands):
-    "commandCharacters": ["!", "."]
+    "commandCharacters": ["!", "."],
+    // Prevents the user who uses both Discord and IRC from being notified by messages they sent themself.
+    // It's done by inserting an invisible character between the Discord nickname in the message that sent to IRC.
+    // (off by default)
+    "preventMentionToAuthor": true,
   }
 ]
 ```

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import irc from 'irc';
 import logger from 'winston';
 import discord from 'discord.js';
-import { substr as substring } from 'runes';
+import { substr } from 'runes';
 import { ConfigurationError } from './errors';
 import { validateChannelMapping } from './validators';
 
@@ -167,7 +167,7 @@ class Bot {
       let displayUsername = nickname;
       if (true) {
         const wordJoiner = '\u2060';
-        displayUsername = substring(displayUsername, 0, 1) + wordJoiner + substring(displayUsername, 1);
+        displayUsername = substr(displayUsername, 0, 1) + wordJoiner + substr(displayUsername, 1);
       }
       if (this.ircNickColor) {
         const colorIndex = (nickname.charCodeAt(0) + nickname.length) % NICK_COLORS.length;

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import irc from 'irc';
 import logger from 'winston';
 import discord from 'discord.js';
+import { substr as substring } from 'runes';
 import { ConfigurationError } from './errors';
 import { validateChannelMapping } from './validators';
 
@@ -31,6 +32,8 @@ class Bot {
     this.discordToken = options.discordToken;
     this.commandCharacters = options.commandCharacters || [];
     this.ircNickColor = options.ircNickColor !== false; // default to true
+    this.preventMentionToAuthor = !!options.preventMentionToAuthor; // default to false
+
     this.channels = _.values(options.channelMapping);
 
     this.channelMapping = {};
@@ -162,9 +165,13 @@ class Bot {
       const nickname = Bot.getDiscordNicknameOnServer(author, fromGuild);
       let text = this.parseText(message);
       let displayUsername = nickname;
+      if (true) {
+        const wordJoiner = '\u2060';
+        displayUsername = substring(displayUsername, 0, 1) + wordJoiner + substring(displayUsername, 1);
+      }
       if (this.ircNickColor) {
         const colorIndex = (nickname.charCodeAt(0) + nickname.length) % NICK_COLORS.length;
-        displayUsername = irc.colors.wrap(NICK_COLORS[colorIndex], nickname);
+        displayUsername = irc.colors.wrap(NICK_COLORS[colorIndex], displayUsername);
       }
 
       if (this.isCommandMessage(text)) {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "discord.js": "11.0.0",
     "irc": "0.5.2",
     "lodash": "^4.17.4",
+    "runes": "^0.4.0",
     "strip-json-comments": "2.0.1",
     "winston": "2.3.1"
   },


### PR DESCRIPTION
It's done by inserting [U+2060 word joiner][1] between the Discord nickname in the message that sent to IRC.

[runes][] was added to the dependencies to handle non-ASCII username properly, like this:
![2017-03-05](https://cloud.githubusercontent.com/assets/543661/23585772/4200912c-01ca-11e7-8c2c-4dd3d767bf1f.PNG)
Some unicode "characters" like รื or 👬🏻 is consist of more than 1 codepoints, so [String.substr()][] could break them.

[1]: http://www.fileformat.info/info/unicode/char/2060/index.htm
[runes]: https://www.npmjs.com/package/runes
[String.substr()]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr