### PR TITLE
Make the bot not crash when a channel mentioned by ID fails to exist

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -139,7 +139,8 @@ class Bot {
       .replace(/\n|\r\n|\r/g, ' ')
       .replace(/<#(\d+)>/g, (match, channelId) => {
         const channel = this.discord.channels.get(channelId);
-        return `#${channel.name}`;
+        if (channel) return `#${channel.name}`;
+        return '#deleted-channel';
       })
       .replace(/<(:\w+:)\d+>/g, (match, emoteName) => emoteName);
   }

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -249,6 +249,30 @@ describe('Bot', function () {
       .should.have.been.calledWith('#irc', expected);
   });
 
+  it('should use #deleted-channel when referenced channel fails to exist', function () {
+    const text = '<#1235>';
+    const guild = createGuildStub();
+    const message = {
+      content: text,
+      mentions: { users: [] },
+      channel: {
+        name: 'discord'
+      },
+      author: {
+        username: 'test',
+        id: 'not bot id'
+      },
+      guild
+    };
+
+    // Discord displays "#deleted-channel" if channel doesn't exist (e.g. <#1235>)
+    // Wrap it in colors:
+    const expected = `<\u000312${message.author.username}\u000f> #deleted-channel`;
+    this.bot.sendToIRC(message);
+    ClientStub.prototype.say
+      .should.have.been.calledWith('#irc', expected);
+  });
+
   it('should convert user mentions from discord', function () {
     const guild = createGuildStub();
     const message = {

--- a/test/stubs/discord-stub.js
+++ b/test/stubs/discord-stub.js
@@ -23,6 +23,7 @@ export default function createDiscordStub(sendMessageStub, findUserStub) {
 
     getChannel(key, value) {
       if (key === 'name' && value !== 'discord') return null;
+      if (key !== '1234' && value === undefined) return null;
       return {
         name: 'discord',
         id: 1234,


### PR DESCRIPTION
## Description
If a channel is referenced in Discord, e.g. `<#1234>`, and the referenced channel does not exist, the bot seems to crash. This commit fixes it to replace this with '#deleted-channel', as Discord does on that side of the bridge.

## Present behavior
Writing `#blah`, `<#test>` and `<#1234>` into IRC causes the bot to show (in Discord):

```
<Throne> #blah
<Throne> <#test>
<Throne> #deleted-channel
```

and then writing the same into the Discord channel causes (in IRC):
```
[22:13:39] <test2> <Throne3d> #blah
[22:13:41] <test2> <Throne3d> <#test>
[22:13:44] * test2 has quit (Client exited)
```

The crash produced:
```
/home/throne3d/discord-irc/dist/bot.js:159
      return `#${channel.name}`;
                        ^

TypeError: Cannot read property 'name' of undefined
    at text.replace.replace (/home/throne3d/discord-irc/dist/bot.js:159:25)
    at RegExp.[Symbol.replace] (native)
    at String.replace (native)
    at Bot.parseText (/home/throne3d/discord-irc/dist/bot.js:157:45)
    at Bot.sendToIRC (/home/throne3d/discord-irc/dist/bot.js:179:23)
    at Client.discord.on.message (/home/throne3d/discord-irc/dist/bot.js:113:12)
    at emitOne (events.js:96:13)
    at Client.emit (events.js:191:7)
    at MessageCreateHandler.handle (/home/throne3d/discord-irc/node_modules/discord.js/src/client/websocket/packets/handlers/MessageCreate.js:9:34)
    at WebSocketPacketManager.handle (/home/throne3d/discord-irc/node_modules/discord.js/src/client/websocket/packets/WebSocketPacketManager.js:120:65)
```

The new test (and stubbing behavior) I add with this patch fails on master as follows:
```
  1) Bot should use #deleted-channel when referenced channel fails to exist:
     TypeError: Cannot read property 'name' of null
      at text.replace.replace (lib/bot.js:7:2326)
      at RegExp.[Symbol.replace] (native)
      at String.replace (native)
      at Bot.parseText (lib/bot.js:7:2147)
      at Bot.sendToIRC (lib/bot.js:8:652)
      at Context.<anonymous> (test/bot.test.js:271:14)
```


## Modified behavior
With the change, it only returns the channel's name where the channel is truthy. (I'm not very acquainted with modern techniques so this might not be the best way to do it? It seems to be `undefined` as returned by `this.discord.channels.get(channelId)` but `null` as returned by the stub, so checking `channel === undefined` didn't catch that.)

Otherwise, it returns `#deleted-channel` (and so writes that into the IRC channel), mirroring the behavior seen in Discord for such invalid channel IDs. This doesn't break any other tests (at least not on my system). The `&& value == undefined` condition is to check for when a second parameter isn't given – I wasn't sure whether to use `&& !value` or something else instead.