### PR TITLE
Parse role mentions appropriately, as with channel and user mentions

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -141,6 +141,11 @@ class Bot {
         const channel = this.discord.channels.get(channelId);
         return `#${channel.name}`;
       })
+      .replace(/<@&(\d+)>/g, (match, roleId) => {
+        const role = message.guild.roles.get(roleId);
+        if (role) return `@${role.name}`;
+        return '@deleted-role';
+      })
       .replace(/<(:\w+:)\d+>/g, (match, emoteName) => emoteName);
   }
 

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -224,6 +224,11 @@ class Bot {
           }
         }
 
+        const role = guild.roles.find('name', search);
+        if (role) {
+          return role;
+        }
+
         return match;
       });
 

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -225,7 +225,7 @@ class Bot {
         }
 
         const role = guild.roles.find('name', search);
-        if (role) {
+        if (role && role.mentionable) {
           return role;
         }
 

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -25,8 +25,9 @@ describe('Bot', function () {
     sandbox.stub(logger, 'error');
     this.sendMessageStub = sandbox.stub();
     this.findUserStub = sandbox.stub();
+    this.findRoleStub = sandbox.stub();
     irc.Client = ClientStub;
-    discord.Client = createDiscordStub(this.sendMessageStub, this.findUserStub);
+    discord.Client = createDiscordStub(this.sendMessageStub, this.findUserStub, this.findRoleStub);
     ClientStub.prototype.say = sandbox.stub();
     ClientStub.prototype.send = sandbox.stub();
     ClientStub.prototype.join = sandbox.stub();
@@ -44,22 +45,14 @@ describe('Bot', function () {
     return attachments;
   };
 
-  const getRole = (key, value) => {
-    if (key !== '12345' && value === undefined) return null;
-    return {
-      name: 'example-role',
-      id: 12345
-    };
-  };
-
-  const createGuildStub = (nickname = null) => ({
+  const createGuildStub = (findRoleStub, nickname = null) => ({
     members: {
       get() {
         return { nickname };
       }
     },
     roles: {
-      get: getRole
+      get: findRoleStub
     }
   });
 
@@ -377,7 +370,7 @@ describe('Bot', function () {
     const newConfig = { ...config, ircNickColor: false };
     const bot = new Bot(newConfig);
     const nickname = 'discord-nickname';
-    const guild = createGuildStub(nickname);
+    const guild = createGuildStub(null, nickname);
     bot.connect();
     const message = {
       content: text,
@@ -426,8 +419,12 @@ describe('Bot', function () {
   });
 
   it('should convert role mentions from discord', function () {
+    const testRole = new discord.Role(this.bot.discord, { name: 'example-role', id: '12345' });
+    this.findRoleStub.withArgs('name', 'example-role').returns(testRole);
+    this.findRoleStub.withArgs('12345').returns(testRole);
+
     const text = '<@&12345>';
-    const guild = createGuildStub();
+    const guild = createGuildStub(this.findRoleStub);
     const message = {
       content: text,
       mentions: { users: [] },
@@ -445,8 +442,11 @@ describe('Bot', function () {
   });
 
   it('should use @deleted-role when referenced role fails to exist', function () {
+    const testRole = new discord.Role(this.bot.discord, { name: 'example-role', id: '12345' });
+    this.findRoleStub.withArgs('12345').returns(testRole);
+
     const text = '<@&12346>';
-    const guild = createGuildStub();
+    const guild = createGuildStub(this.findRoleStub);
     const message = {
       content: text,
       mentions: { users: [] },
@@ -462,5 +462,18 @@ describe('Bot', function () {
 
     // Discord displays "@deleted-role" if role doesn't exist (e.g. <@&12346>)
     this.bot.parseText(message).should.equal('@deleted-role');
+  });
+
+  it('should convert role mentions from IRC', function () {
+    const testRole = new discord.Role(this.bot.discord, { name: 'example-role', id: '12345' });
+    this.findRoleStub.withArgs('name', 'example-role').returns(testRole);
+    this.findRoleStub.withArgs('12345').returns(testRole);
+
+    const username = 'ircuser';
+    const text = 'Hello, @example-role!';
+    const expected = `**<${username}>** Hello, <@&${testRole.id}>!`;
+
+    this.bot.sendToDiscord(username, '#irc', text);
+    this.sendMessageStub.should.have.been.calledWith(expected);
   });
 });

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -464,14 +464,27 @@ describe('Bot', function () {
     this.bot.parseText(message).should.equal('@deleted-role');
   });
 
-  it('should convert role mentions from IRC', function () {
-    const testRole = new discord.Role(this.bot.discord, { name: 'example-role', id: '12345' });
+  it('should convert role mentions from IRC if role mentionable', function () {
+    const testRole = new discord.Role(this.bot.discord, { name: 'example-role', id: '12345', mentionable: true });
     this.findRoleStub.withArgs('name', 'example-role').returns(testRole);
     this.findRoleStub.withArgs('12345').returns(testRole);
 
     const username = 'ircuser';
     const text = 'Hello, @example-role!';
     const expected = `**<${username}>** Hello, <@&${testRole.id}>!`;
+
+    this.bot.sendToDiscord(username, '#irc', text);
+    this.sendMessageStub.should.have.been.calledWith(expected);
+  });
+
+  it('should not convert role mentions from IRC if role not mentionable', function () {
+    const testRole = new discord.Role(this.bot.discord, { name: 'example-role', id: '12345' });
+    this.findRoleStub.withArgs('name', 'example-role').returns(testRole);
+    this.findRoleStub.withArgs('12345').returns(testRole);
+
+    const username = 'ircuser';
+    const text = 'Hello, @example-role!';
+    const expected = `**<${username}>** Hello, @example-role!`;
 
     this.bot.sendToDiscord(username, '#irc', text);
     this.sendMessageStub.should.have.been.calledWith(expected);

--- a/test/stubs/discord-stub.js
+++ b/test/stubs/discord-stub.js
@@ -2,7 +2,7 @@
 import events from 'events';
 import sinon from 'sinon';
 
-export default function createDiscordStub(sendMessageStub, findUserStub) {
+export default function createDiscordStub(sendMessageStub, findUserStub, findRoleStub) {
   return class DiscordStub extends events.EventEmitter {
     constructor() {
       super();
@@ -31,6 +31,10 @@ export default function createDiscordStub(sendMessageStub, findUserStub) {
           members: {
             find: findUserStub,
             get: findUserStub
+          },
+          roles: {
+            find: findRoleStub,
+            get: findRoleStub
           }
         }
       };


### PR DESCRIPTION
## Description
As requested in #186, translate role mentions appropriately between IRC and Discord. This works both ways, so the numbers will be translated into proper text when outputted in IRC, and the plain-text mentions will be made into proper role mentions when outputted in Discord, if (and only if) the role is mentionable.

## Present behavior
As in #186, using e.g. `@sysadmin` in Discord will end up outputting a long string into IRC, e.g. `<@&233558485999…>`. In addition, using `@sysadmin` in IRC will not produce a mention in Discord, even if the sysadmin role is mentionable.

## Modified behavior
If `newrole` is not mentionable and `otherrole` is mentionable, the following output is produced in Discord:
```
Throne3d wrote:
@newrole

IrcBridge wrote:
<Throne> @newrole
<Throne> @otherrole # actually works

Throne3d wrote:
@otherrole # actually works
```
and in IRC:
```
<test2> <Throne3d> @newrole
<Throne> @newrole
<Throne> @otherrole
<test2> <Throne3d> @otherrole
```

I wasn't sure how exactly to set up the tests (you may note the first commit, a1dfdf6, sets up a `const getRole` in `bot.test.js`, which is later removed in favor of a `this.findRoleStub`, behaving somewhat like `this.findUserStub`), but they seem to pass where appropriate and match the style of the other tests at least reasonably well.

This should solve #186.