### PR TITLE
Add custom formatting to IRC & Discord output

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -177,10 +177,7 @@ class Bot {
   }
 
   static substitutePattern(message, patternMapping) {
-    return message.replace(patternMatch, (match, varName) => {
-      if (varName in patternMapping) return patternMapping[varName];
-      return match;
-    });
+    return message.replace(patternMatch, (match, varName) => patternMapping[varName] || match);
   }
 
   sendToIRC(message) {

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -9,6 +9,7 @@ import { formatFromDiscordToIRC, formatFromIRCToDiscord } from './formatting';
 const REQUIRED_FIELDS = ['server', 'nickname', 'channelMapping', 'discordToken'];
 const NICK_COLORS = ['light_blue', 'dark_blue', 'light_red', 'dark_red', 'light_green',
   'dark_green', 'magenta', 'light_magenta', 'orange', 'yellow', 'cyan', 'light_cyan'];
+const patternMatch = /{\$(.+?)}/g;
 
 /**
  * An IRC bot, works as a middleman for all communication
@@ -33,6 +34,17 @@ class Bot {
     this.commandCharacters = options.commandCharacters || [];
     this.ircNickColor = options.ircNickColor !== false; // default to true
     this.channels = _.values(options.channelMapping);
+
+    // "{$keyName}" => "variableValue"
+    // nickname: discord nickname
+    // displayUsername: nickname with wrapped colors
+    // text: the (IRC-formatted) message content
+    // discordChannel: Discord channel (e.g. #general)
+    // ircChannel: IRC channel (e.g. #irc)
+    // attachmentURL: the URL of the attachment (only applicable in formatURLAttachment)
+    this.formatCommandPrelude = options.formatCommandPrelude || 'Command sent from Discord by {$nickname}:';
+    this.formatIRCText = options.formatIRCText || '<{$displayUsername}> {$text}';
+    this.formatURLAttachment = options.formatURLAttachment || '<{$displayUsername}> {$attachmentURL}';
 
     this.channelMapping = {};
 
@@ -176,7 +188,17 @@ class Bot {
       }
 
       if (this.isCommandMessage(text)) {
-        const prelude = `Command sent from Discord by ${nickname}:`;
+        const prelude = this.formatCommandPrelude.replace(patternMatch, (match, varName) => {
+          switch (varName) {
+            case 'nickname': return nickname;
+            case 'displayUsername': return displayUsername;
+            case 'text': return text;
+            case 'discordChannel': return channelName;
+            case 'ircChannel': return ircChannel;
+            default: return match;
+          }
+        });
+
         this.ircClient.say(ircChannel, prelude);
         this.ircClient.say(ircChannel, text);
       } else {
@@ -184,14 +206,35 @@ class Bot {
           // Convert formatting
           text = formatFromDiscordToIRC(text);
 
-          text = `<${displayUsername}> ${text}`;
+          text = this.formatIRCText.replace(patternMatch, (match, varName) => {
+            switch (varName) {
+              case 'nickname': return nickname;
+              case 'displayUsername': return displayUsername;
+              case 'text': return text;
+              case 'discordChannel': return channelName;
+              case 'ircChannel': return ircChannel;
+              default: return match;
+            }
+          });
+
           logger.debug('Sending message to IRC', ircChannel, text);
           this.ircClient.say(ircChannel, text);
         }
 
         if (message.attachments && message.attachments.size) {
           message.attachments.forEach((a) => {
-            const urlMessage = `<${displayUsername}> ${a.url}`;
+            const urlMessage = this.formatURLAttachment.replace(patternMatch, (match, varName) => {
+              switch (varName) {
+                case 'nickname': return nickname;
+                case 'displayUsername': return displayUsername;
+                case 'text': return text;
+                case 'discordChannel': return channelName;
+                case 'ircChannel': return ircChannel;
+                case 'attachmentURL': return a.url;
+                default: return match;
+              }
+            });
+
             logger.debug('Sending attachment URL to IRC', ircChannel, urlMessage);
             this.ircClient.say(ircChannel, urlMessage);
           });

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -175,6 +175,13 @@ class Bot {
     return this.commandCharacters.indexOf(message[0]) !== -1;
   }
 
+  static substitutePattern(message, patternMapping) {
+    return message.replace(patternMatch, (match, varName) => {
+      if (varName in patternMapping) return patternMapping[varName];
+      return match;
+    });
+  }
+
   sendToIRC(message) {
     const author = message.author;
     // Ignore messages sent by the bot itself:
@@ -195,53 +202,33 @@ class Bot {
         displayUsername = irc.colors.wrap(NICK_COLORS[colorIndex], nickname);
       }
 
-      if (this.isCommandMessage(text)) {
-        const prelude = this.formatCommandPrelude.replace(patternMatch, (match, varName) => {
-          switch (varName) {
-            case 'nickname': return nickname;
-            case 'displayUsername': return displayUsername;
-            case 'text': return text;
-            case 'discordChannel': return channelName;
-            case 'ircChannel': return ircChannel;
-            default: return match;
-          }
-        });
+      const patternMap = {
+        nickname,
+        displayUsername,
+        text,
+        discordChannel: channelName,
+        ircChannel
+      };
 
+      if (this.isCommandMessage(text)) {
+        const prelude = Bot.substitutePattern(this.formatCommandPrelude, patternMap);
         this.ircClient.say(ircChannel, prelude);
         this.ircClient.say(ircChannel, text);
       } else {
         if (text !== '') {
           // Convert formatting
           text = formatFromDiscordToIRC(text);
+          patternMap.text = text;
 
-          text = this.formatIRCText.replace(patternMatch, (match, varName) => {
-            switch (varName) {
-              case 'nickname': return nickname;
-              case 'displayUsername': return displayUsername;
-              case 'text': return text;
-              case 'discordChannel': return channelName;
-              case 'ircChannel': return ircChannel;
-              default: return match;
-            }
-          });
-
+          text = Bot.substitutePattern(this.formatIRCText, patternMap);
           logger.debug('Sending message to IRC', ircChannel, text);
           this.ircClient.say(ircChannel, text);
         }
 
         if (message.attachments && message.attachments.size) {
           message.attachments.forEach((a) => {
-            const urlMessage = this.formatURLAttachment.replace(patternMatch, (match, varName) => {
-              switch (varName) {
-                case 'nickname': return nickname;
-                case 'displayUsername': return displayUsername;
-                case 'text': return text;
-                case 'discordChannel': return channelName;
-                case 'ircChannel': return ircChannel;
-                case 'attachmentURL': return a.url;
-                default: return match;
-              }
-            });
+            patternMap.attachmentURL = a.url;
+            const urlMessage = Bot.substitutePattern(this.formatURLAttachment, patternMap);
 
             logger.debug('Sending attachment URL to IRC', ircChannel, urlMessage);
             this.ircClient.say(ircChannel, urlMessage);
@@ -289,18 +276,17 @@ class Bot {
         return match;
       });
 
+      const patternMap = {
+        author,
+        text: withFormat,
+        withMentions,
+        discordChannel: discordChannel.name,
+        ircChannel: channel
+      };
+
       // Add bold formatting:
       // Use custom formatting from config / default formatting with bold author
-      const withAuthor = this.formatDiscord.replace(patternMatch, (match, varName) => {
-        switch (varName) {
-          case 'author': return author;
-          case 'text': return withFormat;
-          case 'withMentions': return withMentions;
-          case 'discordChannel': return discordChannel.name;
-          case 'ircChannel': return channel;
-          default: return match;
-        }
-      });
+      const withAuthor = Bot.substitutePattern(this.formatDiscord, patternMap);
       logger.debug('Sending message to Discord', withAuthor, channel, '->', discordChannelName);
       discordChannel.sendMessage(withAuthor);
     }

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -35,6 +35,7 @@ class Bot {
     this.ircNickColor = options.ircNickColor !== false; // default to true
     this.channels = _.values(options.channelMapping);
 
+    this.format = options.format || {};
     // "{$keyName}" => "variableValue"
     // nickname: discord nickname
     // displayUsername: nickname with wrapped colors
@@ -42,9 +43,9 @@ class Bot {
     // discordChannel: Discord channel (e.g. #general)
     // ircChannel: IRC channel (e.g. #irc)
     // attachmentURL: the URL of the attachment (only applicable in formatURLAttachment)
-    this.formatCommandPrelude = options.formatCommandPrelude || 'Command sent from Discord by {$nickname}:';
-    this.formatIRCText = options.formatIRCText || '<{$displayUsername}> {$text}';
-    this.formatURLAttachment = options.formatURLAttachment || '<{$displayUsername}> {$attachmentURL}';
+    this.formatCommandPrelude = this.format.commandPrelude || 'Command sent from Discord by {$nickname}:';
+    this.formatIRCText = this.format.ircText || '<{$displayUsername}> {$text}';
+    this.formatURLAttachment = this.format.urlAttachment || '<{$displayUsername}> {$attachmentURL}';
 
     // "{$keyName}" => "variableValue"
     // author: IRC nickname
@@ -52,7 +53,7 @@ class Bot {
     // withMentions: text with appropriate mentions reformatted
     // discordChannel: Discord channel (e.g. #general)
     // ircChannel: IRC channel (e.g. #irc)
-    this.formatDiscord = options.formatDiscord || '**<{$author}>** {$withMentions}';
+    this.formatDiscord = this.format.discord || '**<{$author}>** {$withMentions}';
 
     this.channelMapping = {};
 

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -280,7 +280,7 @@ class Bot {
         author,
         text: withFormat,
         withMentions,
-        discordChannel: discordChannel.name,
+        discordChannel: `#${discordChannel.name}`,
         ircChannel: channel
       };
 

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -46,6 +46,14 @@ class Bot {
     this.formatIRCText = options.formatIRCText || '<{$displayUsername}> {$text}';
     this.formatURLAttachment = options.formatURLAttachment || '<{$displayUsername}> {$attachmentURL}';
 
+    // "{$keyName}" => "variableValue"
+    // author: IRC nickname
+    // text: the (Discord-formatted) message content
+    // withMentions: text with appropriate mentions reformatted
+    // discordChannel: Discord channel (e.g. #general)
+    // ircChannel: IRC channel (e.g. #irc)
+    this.formatDiscord = options.formatDiscord || '**<{$author}>** {$withMentions}';
+
     this.channelMapping = {};
 
     // Remove channel passwords from the mapping and lowercase IRC channel names
@@ -282,7 +290,17 @@ class Bot {
       });
 
       // Add bold formatting:
-      const withAuthor = `**<${author}>** ${withMentions}`;
+      // Use custom formatting from config / default formatting with bold author
+      const withAuthor = this.formatDiscord.replace(patternMatch, (match, varName) => {
+        switch (varName) {
+          case 'author': return author;
+          case 'text': return withFormat;
+          case 'withMentions': return withMentions;
+          case 'discordChannel': return discordChannel.name;
+          case 'ircChannel': return channel;
+          default: return match;
+        }
+      });
       logger.debug('Sending message to Discord', withAuthor, channel, '->', discordChannelName);
       discordChannel.sendMessage(withAuthor);
     }

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -599,6 +599,7 @@ describe('Bot', function () {
   it('should not replace unmatched patterns', function () {
     const formatDiscord = '{$unmatchedPattern} stays intact: {$author} {$text}';
     const bot = new Bot({ ...configMsgFormatDefault, formatDiscord });
+    bot.connect();
 
     const username = 'testuser';
     const msg = 'test message';
@@ -610,11 +611,137 @@ describe('Bot', function () {
   it('should respect custom formatting for Discord', function () {
     const formatDiscord = '<{$author}> {$ircChannel} => {$discordChannel}: {$text}';
     const bot = new Bot({ ...configMsgFormatDefault, formatDiscord });
+    bot.connect();
 
     const username = 'test';
     const msg = 'test @user <#1234>';
     const expected = `<test> #irc => #discord: ${msg}`;
     bot.sendToDiscord(username, '#irc', msg);
     this.sendMessageStub.should.have.been.calledWith(expected);
+  });
+
+  it('should successfully send messages with default config', function () {
+    this.bot = new Bot(configMsgFormatDefault);
+    this.bot.connect();
+
+    this.bot.sendToDiscord('testuser', '#irc', 'test message');
+    this.sendMessageStub.should.have.been.calledOnce;
+
+    const guild = createGuildStub();
+    const message = {
+      content: 'test message',
+      mentions: { users: [] },
+      channel: {
+        name: 'discord'
+      },
+      author: {
+        username: 'otherauthor',
+        id: 'not bot id'
+      },
+      guild
+    };
+
+    this.bot.sendToIRC(message);
+    this.sendMessageStub.should.have.been.calledOnce;
+  });
+
+  it('should not replace unmatched patterns', function () {
+    const formatDiscord = '{$unmatchedPattern} stays intact: {$author} {$text}';
+    this.bot = new Bot({ ...configMsgFormatDefault, formatDiscord });
+    this.bot.connect();
+
+    const username = 'testuser';
+    const msg = 'test message';
+    const expected = `{$unmatchedPattern} stays intact: ${username} ${msg}`;
+    this.bot.sendToDiscord(username, '#irc', msg);
+    this.sendMessageStub.should.have.been.calledWith(expected);
+  });
+
+  it('should respect custom formatting for Discord', function () {
+    const formatDiscord = '<{$author}> {$ircChannel} => {$discordChannel}: {$text}';
+    this.bot = new Bot({ ...configMsgFormatDefault, formatDiscord });
+    this.bot.connect();
+
+    const username = 'test';
+    const msg = 'test @user <#1234>';
+    const expected = `<test> #irc => #discord: ${msg}`;
+    this.bot.sendToDiscord(username, '#irc', msg);
+    this.sendMessageStub.should.have.been.calledWith(expected);
+  });
+
+  it('should respect custom formatting for regular IRC output', function () {
+    const formatIRCText = '<{$nickname}> {$discordChannel} => {$ircChannel}: {$text}';
+    this.bot = new Bot({ ...configMsgFormatDefault, formatIRCText });
+    this.bot.connect();
+
+    const guild = createGuildStub();
+    const message = {
+      content: 'test message',
+      mentions: { users: [] },
+      channel: {
+        name: 'discord'
+      },
+      author: {
+        username: 'testauthor',
+        id: 'not bot id'
+      },
+      guild
+    };
+    const expected = '<testauthor> #discord => #irc: test message';
+
+    this.bot.sendToIRC(message);
+    ClientStub.prototype.say.should.have.been.calledWith('#irc', expected);
+  });
+
+  it('should respect custom formatting for commands in IRC output', function () {
+    const formatCommandPrelude = '{$nickname} from {$discordChannel} sent command to {$ircChannel}:';
+    this.bot = new Bot({ ...configMsgFormatDefault, formatCommandPrelude });
+    this.bot.connect();
+
+    const text = '!testcmd';
+    const guild = createGuildStub();
+    const message = {
+      content: text,
+      mentions: { users: [] },
+      channel: {
+        name: 'discord'
+      },
+      author: {
+        username: 'testauthor',
+        id: 'not bot id'
+      },
+      guild
+    };
+    const expected = 'testauthor from #discord sent command to #irc:';
+
+    this.bot.sendToIRC(message);
+    ClientStub.prototype.say.getCall(0).args.should.deep.equal(['#irc', expected]);
+    ClientStub.prototype.say.getCall(1).args.should.deep.equal(['#irc', text]);
+  });
+
+  it('should respect custom formatting for attachment URLs in IRC output', function () {
+    const formatURLAttachment = '<{$nickname}> {$discordChannel} => {$ircChannel}, attachment: {$attachmentURL}';
+    this.bot = new Bot({ ...configMsgFormatDefault, formatURLAttachment });
+    this.bot.connect();
+
+    const attachmentUrl = 'https://image/url.jpg';
+    const guild = createGuildStub();
+    const message = {
+      content: '',
+      mentions: { users: [] },
+      attachments: createAttachments(attachmentUrl),
+      channel: {
+        name: 'discord'
+      },
+      author: {
+        username: 'otherauthor',
+        id: 'not bot id'
+      },
+      guild
+    };
+
+    this.bot.sendToIRC(message);
+    const expected = `<otherauthor> #discord => #irc, attachment: ${attachmentUrl}`;
+    ClientStub.prototype.say.should.have.been.calledWith('#irc', expected);
   });
 });

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -597,8 +597,8 @@ describe('Bot', function () {
   });
 
   it('should not replace unmatched patterns', function () {
-    const formatDiscord = '{$unmatchedPattern} stays intact: {$author} {$text}';
-    const bot = new Bot({ ...configMsgFormatDefault, formatDiscord });
+    const format = { discord: '{$unmatchedPattern} stays intact: {$author} {$text}' };
+    const bot = new Bot({ ...configMsgFormatDefault, format });
     bot.connect();
 
     const username = 'testuser';
@@ -609,8 +609,8 @@ describe('Bot', function () {
   });
 
   it('should respect custom formatting for Discord', function () {
-    const formatDiscord = '<{$author}> {$ircChannel} => {$discordChannel}: {$text}';
-    const bot = new Bot({ ...configMsgFormatDefault, formatDiscord });
+    const format = { discord: '<{$author}> {$ircChannel} => {$discordChannel}: {$text}' };
+    const bot = new Bot({ ...configMsgFormatDefault, format });
     bot.connect();
 
     const username = 'test';
@@ -646,8 +646,8 @@ describe('Bot', function () {
   });
 
   it('should not replace unmatched patterns', function () {
-    const formatDiscord = '{$unmatchedPattern} stays intact: {$author} {$text}';
-    this.bot = new Bot({ ...configMsgFormatDefault, formatDiscord });
+    const format = { discord: '{$unmatchedPattern} stays intact: {$author} {$text}' };
+    this.bot = new Bot({ ...configMsgFormatDefault, format });
     this.bot.connect();
 
     const username = 'testuser';
@@ -658,8 +658,8 @@ describe('Bot', function () {
   });
 
   it('should respect custom formatting for Discord', function () {
-    const formatDiscord = '<{$author}> {$ircChannel} => {$discordChannel}: {$text}';
-    this.bot = new Bot({ ...configMsgFormatDefault, formatDiscord });
+    const format = { discord: '<{$author}> {$ircChannel} => {$discordChannel}: {$text}' };
+    this.bot = new Bot({ ...configMsgFormatDefault, format });
     this.bot.connect();
 
     const username = 'test';
@@ -670,8 +670,8 @@ describe('Bot', function () {
   });
 
   it('should respect custom formatting for regular IRC output', function () {
-    const formatIRCText = '<{$nickname}> {$discordChannel} => {$ircChannel}: {$text}';
-    this.bot = new Bot({ ...configMsgFormatDefault, formatIRCText });
+    const format = { ircText: '<{$nickname}> {$discordChannel} => {$ircChannel}: {$text}' };
+    this.bot = new Bot({ ...configMsgFormatDefault, format });
     this.bot.connect();
 
     const guild = createGuildStub();
@@ -694,8 +694,8 @@ describe('Bot', function () {
   });
 
   it('should respect custom formatting for commands in IRC output', function () {
-    const formatCommandPrelude = '{$nickname} from {$discordChannel} sent command to {$ircChannel}:';
-    this.bot = new Bot({ ...configMsgFormatDefault, formatCommandPrelude });
+    const format = { commandPrelude: '{$nickname} from {$discordChannel} sent command to {$ircChannel}:' };
+    this.bot = new Bot({ ...configMsgFormatDefault, format });
     this.bot.connect();
 
     const text = '!testcmd';
@@ -720,8 +720,8 @@ describe('Bot', function () {
   });
 
   it('should respect custom formatting for attachment URLs in IRC output', function () {
-    const formatURLAttachment = '<{$nickname}> {$discordChannel} => {$ircChannel}, attachment: {$attachmentURL}';
-    this.bot = new Bot({ ...configMsgFormatDefault, formatURLAttachment });
+    const format = { urlAttachment: '<{$nickname}> {$discordChannel} => {$ircChannel}, attachment: {$attachmentURL}' };
+    this.bot = new Bot({ ...configMsgFormatDefault, format });
     this.bot.connect();
 
     const attachmentUrl = 'https://image/url.jpg';

--- a/test/fixtures/msg-formats-default.json
+++ b/test/fixtures/msg-formats-default.json
@@ -1,0 +1,9 @@
+{
+  "nickname": "Reactiflux",
+  "server": "irc.freenode.net",
+  "discordToken": "whatapassword",
+  "commandCharacters": ["!", "."],
+  "channelMapping": {
+    "#discord": "#irc"
+  }
+}


### PR DESCRIPTION
As requested by #13, it might sometimes be useful to have custom formatting in the output for IRC and Discord.

I'm not sure how exactly to add tests for this, as it seems like it's going to need a separate configuration for (almost) each test, and this doesn't look like it'll fit into the current `bot.test.js` file very easily. From a brief glance I can't see a 'context' feature in Chai as there is in RSpec, which would allow me to limit the `beforeEach` to just the tests present, and add separate ones at the end for this. It's possible I'm missing something.

I'm also not too strongly attached to this idea and it might make it harder to implement some things in the future, so if it'd be preferable to drop this, I don't care too strongly. (If people want it desperately enough, they can always just patch these commits on – hopefully it's clearly documenting enough, and it doesn't seem to break current tests.)

I'd appreciate feedback on how to proceed. Thanks.