### PR TITLE
Bridge IRC join/part/quit messages to Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ First you need to create a Discord bot user, which you can do by following the i
     "ircNickColor": false, // Gives usernames a color in IRC for better readability (on by default)
     // Makes the bot hide the username prefix for messages that start
     // with one of these characters (commands):
-    "commandCharacters": ["!", "."]
+    "commandCharacters": ["!", "."],
+    "ircStatusNotices": true // Enables notifications in Discord when people join/part in the relevant IRC channel
   }
 ]
 ```

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -325,7 +325,7 @@ class Bot {
    * @param   channel   The channel to send to
    * @param   text      The text to send to discord
    **/
-  sendToDiscord(channel, text) {
+  sendSpecialToDiscord(channel, text) {
       const discordChannelName = this.invertedMapping[channel.toLowerCase()];
       if (discordChannelName) {
       // #channel -> channel before retrieving:

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -256,8 +256,8 @@ class Bot {
     }
   }
 
-  sendToDiscord(author, channel, text) {
-    const discordChannelName = this.invertedMapping[channel.toLowerCase()];
+  getDiscordChannelFor(ircChannel) {
+    const discordChannelName = this.invertedMapping[ircChannel.toLowerCase()];
     if (discordChannelName) {
       // #channel -> channel before retrieving and select only text channels:
       const discordChannel = discordChannelName.startsWith('#') ? this.discord.channels
@@ -267,66 +267,63 @@ class Bot {
       if (!discordChannel) {
         logger.info('Tried to send a message to a channel the bot isn\'t in: ',
           discordChannelName);
-        return;
+        return null;
+      }
+      return discordChannel;
+    }
+    return null;
+  }
+
+  sendToDiscord(author, channel, text) {
+    const discordChannel = this.getDiscordChannelFor(channel);
+    if (!discordChannel) return;
+
+    // Convert text formatting (bold, italics, underscore)
+    const withFormat = formatFromIRCToDiscord(text);
+
+    const withMentions = withFormat.replace(/@[^\s]+\b/g, (match) => {
+      const search = match.substring(1);
+      const guild = discordChannel.guild;
+      const nickUser = guild.members.find('nickname', search);
+      if (nickUser) {
+        return nickUser;
       }
 
-      // Convert text formatting (bold, italics, underscore)
-      const withFormat = formatFromIRCToDiscord(text);
+      const user = this.discord.users.find('username', search);
+      if (user) {
+        return user;
+      }
 
-      const withMentions = withFormat.replace(/@[^\s]+\b/g, (match) => {
-        const search = match.substring(1);
-        const guild = discordChannel.guild;
-        const nickUser = guild.members.find('nickname', search);
-        if (nickUser) {
-          return nickUser;
-        }
+      const role = guild.roles.find('name', search);
+      if (role && role.mentionable) {
+        return role;
+      }
 
-        const user = this.discord.users.find('username', search);
-        if (user) {
-          return user;
-        }
+      return match;
+    });
 
-        const role = guild.roles.find('name', search);
-        if (role && role.mentionable) {
-          return role;
-        }
+    const patternMap = {
+      author,
+      text: withFormat,
+      withMentions,
+      discordChannel: `#${discordChannel.name}`,
+      ircChannel: channel
+    };
 
-        return match;
-      });
-
-      const patternMap = {
-        author,
-        text: withFormat,
-        withMentions,
-        discordChannel: `#${discordChannel.name}`,
-        ircChannel: channel
-      };
-
-      // Add bold formatting:
-      // Use custom formatting from config / default formatting with bold author
-      const withAuthor = Bot.substitutePattern(this.formatDiscord, patternMap);
-      logger.debug('Sending message to Discord', withAuthor, channel, '->', discordChannelName);
-      discordChannel.sendMessage(withAuthor);
-    }
+    // Add bold formatting:
+    // Use custom formatting from config / default formatting with bold author
+    const withAuthor = Bot.substitutePattern(this.formatDiscord, patternMap);
+    logger.debug('Sending message to Discord', withAuthor, channel, '->', `#${discordChannel.name}`);
+    discordChannel.sendMessage(withAuthor);
   }
 
   /* Sends a message to Discord exactly as it appears */
   sendSpecialToDiscord(channel, text) {
-    const discordChannelName = this.invertedMapping[channel.toLowerCase()];
-    if (discordChannelName) {
-      const discordChannel = this.discord.channels
-        .filter(c => c.type === 'text')
-        .find('name', discordChannelName.slice(1));
+    const discordChannel = this.getDiscordChannelFor(channel);
+    if (!discordChannel) return;
 
-      if (!discordChannel) {
-        logger.info('Tried to send a message to a channel the bot isn\'t in: ',
-          discordChannelName);
-        return;
-      }
-
-      logger.debug('Sending special message to Discord', text, channel, '->', discordChannelName);
-      discordChannel.sendMessage(text);
-    }
+    logger.debug('Sending special message to Discord', text, channel, '->', `#${discordChannel.name}`);
+    discordChannel.sendMessage(text);
   }
 }
 

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -35,6 +35,7 @@ class Bot {
     this.ircNickColor = options.ircNickColor !== false; // default to true
     this.channels = _.values(options.channelMapping);
     this.ircStatusNotices = options.ircStatusNotices;
+    this.announceSelfJoin = options.announceSelfJoin;
 
     this.format = options.format || {};
     // "{$keyName}" => "variableValue"
@@ -122,7 +123,8 @@ class Bot {
     });
 
     this.ircClient.on('join', (channel, nick) => {
-      if (!this.ircStatusNotices || nick === this.nickname) return;
+      if (!this.ircStatusNotices) return;
+      if (nick === this.nickname && !this.announceSelfJoin) return;
       this.sendSpecialToDiscord(channel, `*${nick}* has joined the channel`);
     });
 

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -326,21 +326,21 @@ class Bot {
    * @param   text      The text to send to discord
    **/
   sendSpecialToDiscord(channel, text) {
-      const discordChannelName = this.invertedMapping[channel.toLowerCase()];
-      if (discordChannelName) {
-      // #channel -> channel before retrieving:
-        const discordChannel = this.discord.channels.get('name', discordChannelName.slice(1));
+    const discordChannelName = this.invertedMapping[channel.toLowerCase()];
+    if (discordChannelName) {
+    // #channel -> channel before retrieving:
+      const discordChannel = this.discord.channels.get('name', discordChannelName.slice(1));
 
-        if (!discordChannel) {
-          logger.info('Tried to send a message to a channel the bot isn\'t in: ',
-          discordChannelName);
-          return;
-        }
-
-        logger.debug('Sending special message to Discord', text, channel, '->', discordChannelName);
-        this.discord.sendMessage(discordChannel, text);
+      if (!discordChannel) {
+        logger.info('Tried to send a message to a channel the bot isn\'t in: ',
+        discordChannelName);
+        return;
       }
+
+      logger.debug('Sending special message to Discord', text, channel, '->', discordChannelName);
+      this.discord.sendMessage(discordChannel, text);
     }
+  }
 }
 
 export default Bot;

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -119,14 +119,14 @@ class Bot {
     this.ircClient.on('notice', (author, to, text) => {
       this.sendToDiscord(author, to, `*${text}*`);
     });
-
+    
     /**
      * Notify Discord that an IRC client has joined
      * @param   channel   The channel the user joined
      * @param   user      The nickname of the user who joined
      * @param   text      undefined?
      **/
-    this.ircClient.on('join', function (channel, user) {
+    this.ircClient.on('join', (channel, user) => {
       this.sendSpecialToDiscord(channel, `*${user}* has joined the channel`);
     });
 
@@ -136,7 +136,7 @@ class Bot {
      * @param   user      The nickname of the user who parted
      * @param   text      undefined?
      **/
-    this.ircClient.on('part', function (channel, user) {
+    this.ircClient.on('part', (channel, user) => {
       this.sendSpecialToDiscord(channel, `*${user}* has left the channel`);
     });
 
@@ -146,10 +146,10 @@ class Bot {
      * @param   reason    The reason why the user quit
      * @param   channel   The channel(s?) they quit from)
      **/
-    this.ircClient.on('quit', function (user, reason, channel) {
+    this.ircClient.on('quit', (user, reason, channel) => {
       this.sendSpecialToDiscord(String(channel), `*${user}* has quit (${reason})`);
     });
-
+    
     this.ircClient.on('action', (author, to, text) => {
       this.sendToDiscord(author, to, `_${text}_`);
     });

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -126,8 +126,8 @@ class Bot {
      * @param   user      The nickname of the user who joined
      * @param   text      undefined?
      **/
-    this.ircClient.on('join', function (channel, user, text) {
-      this.sendSpecialToDiscord(channel, '*' + user + '* has joined the channel');
+    this.ircClient.on('join', function (channel, user) {
+      this.sendSpecialToDiscord(channel, `*${user}* has joined the channel`);
     });
 
     /**
@@ -136,8 +136,8 @@ class Bot {
      * @param   user      The nickname of the user who parted
      * @param   text      undefined?
      **/
-    this.ircClient.on('part', function (channel, user, text) {
-      this.sendSpecialToDiscord(channel, '*' + user + '* has left the channel');
+    this.ircClient.on('part', function (channel, user) {
+      this.sendSpecialToDiscord(channel, `*${user}* has left the channel`);
     });
 
     /**
@@ -147,7 +147,7 @@ class Bot {
      * @param   channel   The channel(s?) they quit from)
      **/
     this.ircClient.on('quit', function (user, reason, channel) {
-      this.sendSpecialToDiscord(channel + '', '*' + user + '* has quit (' + reason + ')');
+      this.sendSpecialToDiscord(String(channel), `*${user}* has quit (${reason})`);
     });
 
     this.ircClient.on('action', (author, to, text) => {

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -122,17 +122,17 @@ class Bot {
     });
 
     this.ircClient.on('join', (channel, nick) => {
-      if (!this.ircStatusNotices) return;
+      if (!this.ircStatusNotices || nick === this.nickname) return;
       this.sendSpecialToDiscord(channel, `*${nick}* has joined the channel`);
     });
 
     this.ircClient.on('part', (channel, nick, reason) => {
-      if (!this.ircStatusNotices) return;
+      if (!this.ircStatusNotices || nick === this.nickname) return;
       this.sendSpecialToDiscord(channel, `*${nick}* has left the channel (${reason})`);
     });
 
     this.ircClient.on('quit', (nick, reason, channels) => {
-      if (!this.ircStatusNotices) return;
+      if (!this.ircStatusNotices || nick === this.nickname) return;
       channels.forEach((channel) => {
         this.sendSpecialToDiscord(channel, `*${nick}* has quit (${reason})`);
       });

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -129,7 +129,7 @@ class Bot {
     this.ircClient.on('join', function (channel, user, text) {
       this.sendSpecialToDiscord(channel, '*' + user + '* has joined the channel');
     });
-	  
+
     /**
      * Notify Discord that an IRC client has parted
      * @param   channel   The channel the user parted
@@ -139,7 +139,7 @@ class Bot {
     this.ircClient.on('part', function (channel, user, text) {
       this.sendSpecialToDiscord(channel, '*' + user + '* has left the channel');
     });
-	  
+
     /**
      * Notify Discord that an IRC client has joined
      * @param   user      The nickname of the user who quit

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -242,13 +242,6 @@ class Bot {
         const prelude = Bot.substitutePattern(this.formatCommandPrelude, patternMap);
         this.ircClient.say(ircChannel, prelude);
         this.ircClient.say(ircChannel, text);
-      } else if (message.attachments && message.attachments.length) {
-        message.attachments.forEach(a => {
-          const urlMessage =
-            `${coloredUsername} posted an attachment to ${channelName} on Discord: ${a.url}`;
-          logger.debug('Sending attachment URL to IRC', ircChannel, urlMessage);
-          this.ircClient.say(ircChannel, urlMessage);
-        });
       } else {
         if (text !== '') {
           // Convert formatting
@@ -328,7 +321,7 @@ class Bot {
   }
 
   /**
-   * Sends a message to Discord exactly as it appears 
+   * Sends a message to Discord exactly as it appears
    * @param   channel   The channel to send to
    * @param   text      The text to send to discord
    **/

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -125,11 +125,13 @@ class Bot {
     });
 
     this.ircClient.on('part', (channel, nick, reason) => {
-      this.sendSpecialToDiscord(channel, `*${nick}* has left the channel`);
+      this.sendSpecialToDiscord(channel, `*${nick}* has left the channel (${reason})`);
     });
 
     this.ircClient.on('quit', (nick, reason, channels) => {
-      this.sendSpecialToDiscord(String(channel), `*${nick}* has quit (${reason})`);
+      channels.forEach((channel) => {
+        this.sendSpecialToDiscord(channel, `*${nick}* has quit (${reason})`);
+      });
     });
 
     this.ircClient.on('action', (author, to, text) => {

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -119,7 +119,7 @@ class Bot {
     this.ircClient.on('notice', (author, to, text) => {
       this.sendToDiscord(author, to, `*${text}*`);
     });
-    
+
     /**
      * Notify Discord that an IRC client has joined
      * @param   channel   The channel the user joined
@@ -149,7 +149,7 @@ class Bot {
     this.ircClient.on('quit', (user, reason, channel) => {
       this.sendSpecialToDiscord(String(channel), `*${user}* has quit (${reason})`);
     });
-    
+
     this.ircClient.on('action', (author, to, text) => {
       this.sendToDiscord(author, to, `_${text}_`);
     });

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -130,23 +130,23 @@ class Bot {
       this.sendSpecialToDiscord(channel, '*' + user + '* has joined the channel');
     });
 	  
-	  /**
+    /**
      * Notify Discord that an IRC client has parted
      * @param   channel   The channel the user parted
      * @param   user      The nickname of the user who parted
      * @param   text      undefined?
      **/
-	  this.ircClient.on('part', function (channel, user, text) {
+    this.ircClient.on('part', function (channel, user, text) {
       this.sendSpecialToDiscord(channel, '*' + user + '* has left the channel');
     });
 	  
-	  /**
+    /**
      * Notify Discord that an IRC client has joined
      * @param   user      The nickname of the user who quit
      * @param   reason    The reason why the user quit
      * @param   channel   The channel(s?) they quit from)
      **/
-	  this.ircClient.on('quit', function (user, reason, channel) {
+    this.ircClient.on('quit', function (user, reason, channel) {
       this.sendSpecialToDiscord(channel + '', '*' + user + '* has quit (' + reason + ')');
     });
 

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -34,6 +34,7 @@ class Bot {
     this.commandCharacters = options.commandCharacters || [];
     this.ircNickColor = options.ircNickColor !== false; // default to true
     this.channels = _.values(options.channelMapping);
+    this.ircStatusNotices = options.ircStatusNotices;
 
     this.format = options.format || {};
     // "{$keyName}" => "variableValue"
@@ -121,14 +122,17 @@ class Bot {
     });
 
     this.ircClient.on('join', (channel, nick) => {
+      if (!this.ircStatusNotices) return;
       this.sendSpecialToDiscord(channel, `*${nick}* has joined the channel`);
     });
 
     this.ircClient.on('part', (channel, nick, reason) => {
+      if (!this.ircStatusNotices) return;
       this.sendSpecialToDiscord(channel, `*${nick}* has left the channel (${reason})`);
     });
 
     this.ircClient.on('quit', (nick, reason, channels) => {
+      if (!this.ircStatusNotices) return;
       channels.forEach((channel) => {
         this.sendSpecialToDiscord(channel, `*${nick}* has quit (${reason})`);
       });

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -125,18 +125,18 @@ class Bot {
     this.ircClient.on('join', (channel, nick) => {
       if (!this.ircStatusNotices) return;
       if (nick === this.nickname && !this.announceSelfJoin) return;
-      this.sendSpecialToDiscord(channel, `*${nick}* has joined the channel`);
+      this.sendExactToDiscord(channel, `*${nick}* has joined the channel`);
     });
 
     this.ircClient.on('part', (channel, nick, reason) => {
       if (!this.ircStatusNotices || nick === this.nickname) return;
-      this.sendSpecialToDiscord(channel, `*${nick}* has left the channel (${reason})`);
+      this.sendExactToDiscord(channel, `*${nick}* has left the channel (${reason})`);
     });
 
     this.ircClient.on('quit', (nick, reason, channels) => {
       if (!this.ircStatusNotices || nick === this.nickname) return;
       channels.forEach((channel) => {
-        this.sendSpecialToDiscord(channel, `*${nick}* has quit (${reason})`);
+        this.sendExactToDiscord(channel, `*${nick}* has quit (${reason})`);
       });
     });
 
@@ -256,7 +256,7 @@ class Bot {
     }
   }
 
-  getDiscordChannelFor(ircChannel) {
+  findDiscordChannel(ircChannel) {
     const discordChannelName = this.invertedMapping[ircChannel.toLowerCase()];
     if (discordChannelName) {
       // #channel -> channel before retrieving and select only text channels:
@@ -275,7 +275,7 @@ class Bot {
   }
 
   sendToDiscord(author, channel, text) {
-    const discordChannel = this.getDiscordChannelFor(channel);
+    const discordChannel = this.findDiscordChannel(channel);
     if (!discordChannel) return;
 
     // Convert text formatting (bold, italics, underscore)
@@ -318,8 +318,8 @@ class Bot {
   }
 
   /* Sends a message to Discord exactly as it appears */
-  sendSpecialToDiscord(channel, text) {
-    const discordChannel = this.getDiscordChannelFor(channel);
+  sendExactToDiscord(channel, text) {
+    const discordChannel = this.findDiscordChannel(channel);
     if (!discordChannel) return;
 
     logger.debug('Sending special message to Discord', text, channel, '->', `#${discordChannel.name}`);

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -119,7 +119,7 @@ class Bot {
     this.ircClient.on('notice', (author, to, text) => {
       this.sendToDiscord(author, to, `*${text}*`);
     });
-    
+
     /**
      * Notify Discord that an IRC client has joined
      * @param   channel   The channel the user joined
@@ -242,6 +242,13 @@ class Bot {
         const prelude = Bot.substitutePattern(this.formatCommandPrelude, patternMap);
         this.ircClient.say(ircChannel, prelude);
         this.ircClient.say(ircChannel, text);
+      } else if (message.attachments && message.attachments.length) {
+        message.attachments.forEach(a => {
+          const urlMessage =
+            `${coloredUsername} posted an attachment to ${channelName} on Discord: ${a.url}`;
+          logger.debug('Sending attachment URL to IRC', ircChannel, urlMessage);
+          this.ircClient.say(ircChannel, urlMessage);
+        });
       } else {
         if (text !== '') {
           // Convert formatting
@@ -319,7 +326,7 @@ class Bot {
       discordChannel.sendMessage(withAuthor);
     }
   }
-  
+
   /**
    * Sends a message to Discord exactly as it appears 
    * @param   channel   The channel to send to

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -119,6 +119,36 @@ class Bot {
     this.ircClient.on('notice', (author, to, text) => {
       this.sendToDiscord(author, to, `*${text}*`);
     });
+    
+    /**
+     * Notify Discord that an IRC client has joined
+     * @param   channel   The channel the user joined
+     * @param   user      The nickname of the user who joined
+     * @param   text      undefined?
+     **/
+    this.ircClient.on('join', function (channel, user, text) {
+      this.sendSpecialToDiscord(channel, '*' + user + '* has joined the channel');
+    });
+	  
+	  /**
+     * Notify Discord that an IRC client has parted
+     * @param   channel   The channel the user parted
+     * @param   user      The nickname of the user who parted
+     * @param   text      undefined?
+     **/
+	  this.ircClient.on('part', function (channel, user, text) {
+      this.sendSpecialToDiscord(channel, '*' + user + '* has left the channel');
+    });
+	  
+	  /**
+     * Notify Discord that an IRC client has joined
+     * @param   user      The nickname of the user who quit
+     * @param   reason    The reason why the user quit
+     * @param   channel   The channel(s?) they quit from)
+     **/
+	  this.ircClient.on('quit', function (user, reason, channel) {
+      this.sendSpecialToDiscord(channel + '', '*' + user + '* has quit (' + reason + ')');
+    });
 
     this.ircClient.on('action', (author, to, text) => {
       this.sendToDiscord(author, to, `_${text}_`);
@@ -289,6 +319,28 @@ class Bot {
       discordChannel.sendMessage(withAuthor);
     }
   }
+  
+  /**
+   * Sends a message to Discord exactly as it appears 
+   * @param   channel   The channel to send to
+   * @param   text      The text to send to discord
+   **/
+  sendToDiscord(channel, text) {
+      const discordChannelName = this.invertedMapping[channel.toLowerCase()];
+      if (discordChannelName) {
+      // #channel -> channel before retrieving:
+        const discordChannel = this.discord.channels.get('name', discordChannelName.slice(1));
+
+        if (!discordChannel) {
+          logger.info('Tried to send a message to a channel the bot isn\'t in: ',
+          discordChannelName);
+          return;
+        }
+
+        logger.debug('Sending special message to Discord', text, channel, '->', discordChannelName);
+        this.discord.sendMessage(discordChannel, text);
+      }
+    }
 }
 
 export default Bot;

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -120,34 +120,16 @@ class Bot {
       this.sendToDiscord(author, to, `*${text}*`);
     });
 
-    /**
-     * Notify Discord that an IRC client has joined
-     * @param   channel   The channel the user joined
-     * @param   user      The nickname of the user who joined
-     * @param   text      undefined?
-     **/
-    this.ircClient.on('join', (channel, user) => {
-      this.sendSpecialToDiscord(channel, `*${user}* has joined the channel`);
+    this.ircClient.on('join', (channel, nick) => {
+      this.sendSpecialToDiscord(channel, `*${nick}* has joined the channel`);
     });
 
-    /**
-     * Notify Discord that an IRC client has parted
-     * @param   channel   The channel the user parted
-     * @param   user      The nickname of the user who parted
-     * @param   text      undefined?
-     **/
-    this.ircClient.on('part', (channel, user) => {
-      this.sendSpecialToDiscord(channel, `*${user}* has left the channel`);
+    this.ircClient.on('part', (channel, nick, reason) => {
+      this.sendSpecialToDiscord(channel, `*${nick}* has left the channel`);
     });
 
-    /**
-     * Notify Discord that an IRC client has joined
-     * @param   user      The nickname of the user who quit
-     * @param   reason    The reason why the user quit
-     * @param   channel   The channel(s?) they quit from)
-     **/
-    this.ircClient.on('quit', (user, reason, channel) => {
-      this.sendSpecialToDiscord(String(channel), `*${user}* has quit (${reason})`);
+    this.ircClient.on('quit', (nick, reason, channels) => {
+      this.sendSpecialToDiscord(String(channel), `*${nick}* has quit (${reason})`);
     });
 
     this.ircClient.on('action', (author, to, text) => {
@@ -320,25 +302,22 @@ class Bot {
     }
   }
 
-  /**
-   * Sends a message to Discord exactly as it appears
-   * @param   channel   The channel to send to
-   * @param   text      The text to send to discord
-   **/
+  /* Sends a message to Discord exactly as it appears */
   sendSpecialToDiscord(channel, text) {
     const discordChannelName = this.invertedMapping[channel.toLowerCase()];
     if (discordChannelName) {
-    // #channel -> channel before retrieving:
-      const discordChannel = this.discord.channels.get('name', discordChannelName.slice(1));
+      const discordChannel = this.discord.channels
+        .filter(c => c.type === 'text')
+        .find('name', discordChannelName.slice(1));
 
       if (!discordChannel) {
         logger.info('Tried to send a message to a channel the bot isn\'t in: ',
-        discordChannelName);
+          discordChannelName);
         return;
       }
 
       logger.debug('Sending special message to Discord', text, channel, '->', discordChannelName);
-      this.discord.sendMessage(discordChannel, text);
+      discordChannel.sendMessage(text);
     }
   }
 }

--- a/test/bot-events.test.js
+++ b/test/bot-events.test.js
@@ -133,13 +133,23 @@ describe('Bot Events', function () {
     bot.sendSpecialToDiscord.should.have.been.calledWithExactly(channel, text);
   });
 
-  it('should not announce itself joining', function () {
+  it('should not announce itself joining by default', function () {
     const bot = createBot({ ...config, ircStatusNotices: true });
     bot.connect();
     const channel = '#channel';
     const nick = bot.nickname;
     bot.ircClient.emit('join', channel, nick);
     bot.sendSpecialToDiscord.should.not.have.been.called;
+  });
+
+  it('should be possible to get the bot to announce itself joining', function () {
+    const bot = createBot({ ...config, ircStatusNotices: true, announceSelfJoin: true });
+    bot.connect();
+    const channel = '#channel';
+    const nick = this.bot.nickname;
+    const text = `*${nick}* has joined the channel`;
+    bot.ircClient.emit('join', channel, nick);
+    bot.sendSpecialToDiscord.should.have.been.calledWithExactly(channel, text);
   });
 
   it('should send part messages to discord when config enabled', function () {

--- a/test/bot-events.test.js
+++ b/test/bot-events.test.js
@@ -24,7 +24,7 @@ describe('Bot Events', function () {
     const bot = new Bot(useConfig);
     bot.sendToIRC = sandbox.stub();
     bot.sendToDiscord = sandbox.stub();
-    bot.sendSpecialToDiscord = sandbox.stub();
+    bot.sendExactToDiscord = sandbox.stub();
     return bot;
   };
 
@@ -130,7 +130,7 @@ describe('Bot Events', function () {
     const nick = 'user';
     const text = `*${nick}* has joined the channel`;
     bot.ircClient.emit('join', channel, nick);
-    bot.sendSpecialToDiscord.should.have.been.calledWithExactly(channel, text);
+    bot.sendExactToDiscord.should.have.been.calledWithExactly(channel, text);
   });
 
   it('should not announce itself joining by default', function () {
@@ -139,7 +139,7 @@ describe('Bot Events', function () {
     const channel = '#channel';
     const nick = bot.nickname;
     bot.ircClient.emit('join', channel, nick);
-    bot.sendSpecialToDiscord.should.not.have.been.called;
+    bot.sendExactToDiscord.should.not.have.been.called;
   });
 
   it('should be possible to get the bot to announce itself joining', function () {
@@ -149,7 +149,7 @@ describe('Bot Events', function () {
     const nick = this.bot.nickname;
     const text = `*${nick}* has joined the channel`;
     bot.ircClient.emit('join', channel, nick);
-    bot.sendSpecialToDiscord.should.have.been.calledWithExactly(channel, text);
+    bot.sendExactToDiscord.should.have.been.calledWithExactly(channel, text);
   });
 
   it('should send part messages to discord when config enabled', function () {
@@ -160,7 +160,7 @@ describe('Bot Events', function () {
     const reason = 'Leaving';
     const text = `*${nick}* has left the channel (${reason})`;
     bot.ircClient.emit('part', channel, nick, reason);
-    bot.sendSpecialToDiscord.should.have.been.calledWithExactly(channel, text);
+    bot.sendExactToDiscord.should.have.been.calledWithExactly(channel, text);
   });
 
   it('should send quit messages to discord when config enabled', function () {
@@ -172,8 +172,8 @@ describe('Bot Events', function () {
     const reason = 'Quit: Leaving';
     const text = `*${nick}* has quit (${reason})`;
     bot.ircClient.emit('quit', nick, reason, [channel1, channel2]);
-    bot.sendSpecialToDiscord.getCall(0).args.should.deep.equal([channel1, text]);
-    bot.sendSpecialToDiscord.getCall(1).args.should.deep.equal([channel2, text]);
+    bot.sendExactToDiscord.getCall(0).args.should.deep.equal([channel1, text]);
+    bot.sendExactToDiscord.getCall(1).args.should.deep.equal([channel2, text]);
   });
 
   it('should be possible to disable join/part/quit messages', function () {
@@ -187,7 +187,7 @@ describe('Bot Events', function () {
     bot.ircClient.emit('part', channel, nick, reason);
     bot.ircClient.emit('join', channel, nick);
     bot.ircClient.emit('quit', nick, reason, [channel]);
-    bot.sendSpecialToDiscord.should.not.have.been.called;
+    bot.sendExactToDiscord.should.not.have.been.called;
   });
 
   it('should not listen to discord debug messages in production', function () {

--- a/test/bot-events.test.js
+++ b/test/bot-events.test.js
@@ -133,6 +133,15 @@ describe('Bot Events', function () {
     bot.sendSpecialToDiscord.should.have.been.calledWithExactly(channel, text);
   });
 
+  it('should not announce itself joining', function () {
+    const bot = createBot({ ...config, ircStatusNotices: true });
+    bot.connect();
+    const channel = '#channel';
+    const nick = bot.nickname;
+    bot.ircClient.emit('join', channel, nick);
+    bot.sendSpecialToDiscord.should.not.have.been.called;
+  });
+
   it('should send part messages to discord when config enabled', function () {
     const bot = createBot({ ...config, ircStatusNotices: true });
     bot.connect();

--- a/test/bot-events.test.js
+++ b/test/bot-events.test.js
@@ -23,6 +23,7 @@ describe('Bot Events', function () {
     const bot = new Bot(config);
     bot.sendToIRC = sandbox.stub();
     bot.sendToDiscord = sandbox.stub();
+    bot.sendSpecialToDiscord = sandbox.stub();
     return bot;
   };
 
@@ -119,6 +120,34 @@ describe('Bot Events', function () {
     const message = {};
     this.bot.ircClient.emit('action', author, channel, text, message);
     this.bot.sendToDiscord.should.have.been.calledWithExactly(author, channel, formattedText);
+  });
+
+  it('should send join messages to discord', function () {
+    const channel = '#channel';
+    const nick = 'user';
+    const text = `*${nick}* has joined the channel`;
+    this.bot.ircClient.emit('join', channel, nick);
+    this.bot.sendSpecialToDiscord.should.have.been.calledWithExactly(channel, text);
+  });
+
+  it('should send part messages to discord', function () {
+    const channel = '#channel';
+    const nick = 'user';
+    const reason = 'Leaving';
+    const text = `*${nick}* has left the channel (${reason})`;
+    this.bot.ircClient.emit('part', channel, nick, reason);
+    this.bot.sendSpecialToDiscord.should.have.been.calledWithExactly(channel, text);
+  });
+
+  it('should send quit messages to discord', function () {
+    const channel1 = '#channel1';
+    const channel2 = '#channel2';
+    const nick = 'user';
+    const reason = 'Quit: Leaving';
+    const text = `*${nick}* has quit (${reason})`;
+    this.bot.ircClient.emit('quit', nick, reason, [channel1, channel2]);
+    this.bot.sendSpecialToDiscord.getCall(0).args.should.deep.equal([channel1, text]);
+    this.bot.sendSpecialToDiscord.getCall(1).args.should.deep.equal([channel2, text]);
   });
 
   it('should not listen to discord debug messages in production', function () {

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -99,19 +99,19 @@ describe('Bot', function () {
 
   it('should not send special messages to discord if the channel isn\'t in the channel mapping',
   function () {
-    this.bot.sendSpecialToDiscord('#no-irc', 'message');
+    this.bot.sendExactToDiscord('#no-irc', 'message');
     this.sendMessageStub.should.not.have.been.called;
   });
 
   it('should not send special messages to discord if it isn\'t in the channel',
   function () {
-    this.bot.sendSpecialToDiscord('#otherirc', 'message');
+    this.bot.sendExactToDiscord('#otherirc', 'message');
     this.sendMessageStub.should.not.have.been.called;
   });
 
   it('should send special messages to discord',
   function () {
-    this.bot.sendSpecialToDiscord('#irc', 'message');
+    this.bot.sendExactToDiscord('#irc', 'message');
     this.sendMessageStub.should.have.been.calledWith('message');
     this.debugSpy.should.have.been.calledWith('Sending special message to Discord', 'message', '#irc', '->', '#discord');
   });

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -91,6 +91,12 @@ describe('Bot', function () {
     this.sendMessageStub.should.have.been.calledWith(formatted);
   });
 
+  it('should not send special messages to discord if the channel isn\'t in the channel mapping',
+  function () {
+    this.bot.sendSpecialToDiscord('#otherirc', 'message');
+    this.sendMessageStub.should.not.have.been.called;
+  });
+
   it('should not color irc messages if the option is disabled', function () {
     const text = 'testmessage';
     const newConfig = { ...config, ircNickColor: false };

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -79,6 +79,12 @@ describe('Bot', function () {
 
   it('should not send messages to discord if the channel isn\'t in the channel mapping',
   function () {
+    this.bot.sendToDiscord('user', '#no-irc', 'message');
+    this.sendMessageStub.should.not.have.been.called;
+  });
+
+  it('should not send messages to discord if it isn\'t in the channel',
+  function () {
     this.bot.sendToDiscord('user', '#otherirc', 'message');
     this.sendMessageStub.should.not.have.been.called;
   });
@@ -92,6 +98,12 @@ describe('Bot', function () {
   });
 
   it('should not send special messages to discord if the channel isn\'t in the channel mapping',
+  function () {
+    this.bot.sendSpecialToDiscord('#no-irc', 'message');
+    this.sendMessageStub.should.not.have.been.called;
+  });
+
+  it('should not send special messages to discord if it isn\'t in the channel',
   function () {
     this.bot.sendSpecialToDiscord('#otherirc', 'message');
     this.sendMessageStub.should.not.have.been.called;

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -21,9 +21,9 @@ describe('Bot', function () {
   });
 
   beforeEach(function () {
-    sandbox.stub(logger, 'info');
-    sandbox.stub(logger, 'debug');
-    sandbox.stub(logger, 'error');
+    this.infoSpy = sandbox.stub(logger, 'info');
+    this.debugSpy = sandbox.stub(logger, 'debug');
+    this.errorSpy = sandbox.stub(logger, 'error');
     this.sendMessageStub = sandbox.stub();
     this.findUserStub = sandbox.stub();
     this.findRoleStub = sandbox.stub();
@@ -95,6 +95,13 @@ describe('Bot', function () {
   function () {
     this.bot.sendSpecialToDiscord('#otherirc', 'message');
     this.sendMessageStub.should.not.have.been.called;
+  });
+
+  it('should send special messages to discord',
+  function () {
+    this.bot.sendSpecialToDiscord('#irc', 'message');
+    this.sendMessageStub.should.have.been.calledWith('message');
+    this.debugSpy.should.have.been.calledWith('Sending special message to Discord', 'message', '#irc', '->', '#discord');
   });
 
   it('should not color irc messages if the option is disabled', function () {


### PR DESCRIPTION
As in PR #40, this bridges the join/part/quit messages from IRC to Discord. It builds on that PR (thanks, @Ratismal), rebasing it onto master (and accidentally doing something stupid in the rebase, which a later commit fixes).

This adds two config settings:

* ~~`disableJoinPartMsgs` – if set to true, the bot won't announce any~~ `ircStatusNotices` – if set to true, the bot will announce join/part/quit messages (if not set, overrides below)
* `announceSelfJoin` – if set to true, the bot *will* announce itself (by default it skips any join events involving itself)

There are tests to ensure it works appropriately, and manual testing seems to show it working well. I hope this PR has more of a chance of getting merged?