### PR TITLE
Convert username mentions even if nickname set

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -213,10 +213,7 @@ class Bot {
 
         const user = this.discord.users.find('username', search);
         if (user) {
-          const nickname = guild.members.get(user.id).nickname;
-          if (!nickname || nickname === search) {
-            return user;
-          }
+          return user;
         }
 
         return match;

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -400,15 +400,15 @@ describe('Bot', function () {
     this.sendMessageStub.should.have.been.calledWith(expected);
   });
 
-  it('should not convert username mentions from IRC if nickname differs', function () {
+  it('should convert username mentions from IRC even if nickname differs', function () {
     const testUser = new discord.User(this.bot.discord, { username: 'testuser', id: '123', nickname: 'somenickname' });
     this.findUserStub.withArgs('username', testUser.username).returns(testUser);
     this.findUserStub.withArgs('nickname', 'somenickname').returns(testUser);
     this.findUserStub.withArgs('id', testUser.id).returns(testUser);
 
     const username = 'ircuser';
-    const text = 'Hello, @username!';
-    const expected = `**<${username}>** Hello, @username!`;
+    const text = 'Hello, @testuser!';
+    const expected = `**<${username}>** Hello, <@${testUser.id}>!`;
 
     this.bot.sendToDiscord(username, '#irc', text);
     this.sendMessageStub.should.have.been.calledWith(expected);


### PR DESCRIPTION
In Discord, using `@username` pings the person with the username even if they currently have their nickname set to something else. As nicknames can have non-ASCII characters in them (or rather, characters that constitute a 'boundary' per the `/@[^\s]+\b/g` regex to match @-mentions of usernames), and usernames don't tend to (or perhaps can't), enabling username mentions even when a nickname is set would allow IRC users to still mention users with such nicknames.

I can't immediately think of a use-case where this distinction would be useful (or expected), and as Discord itself handles it differently I don't think this is the correct behavior.

In addition, I think the test for this behavior (not creating a mention if nickname differs from username) was broken. See where `'Hello, @username!'` becomes `'Hello, @testuser!'` below – it wasn't in fact referencing an existent user, so this was instead testing that mentioning a nonexistent user doesn't change the mention text.