### PR TITLE
Fix IRC quit messages sending to all channels by tracking users

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -57,6 +57,9 @@ class Bot {
     // ircChannel: IRC channel (e.g. #irc)
     this.formatDiscord = this.format.discord || '**<{$author}>** {$withMentions}';
 
+    // Keep track of { channel => [list, of, usernames] } for ircStatusNotices
+    this.channelUsers = {};
+
     this.channelMapping = {};
 
     // Remove channel passwords from the mapping and lowercase IRC channel names
@@ -125,19 +128,36 @@ class Bot {
     this.ircClient.on('join', (channel, nick) => {
       if (!this.ircStatusNotices) return;
       if (nick === this.nickname && !this.announceSelfJoin) return;
+      // self-join is announced before names (which includes own nick)
+      // so don't add nick to channelUsers
+      if (nick !== this.nickname) this.channelUsers[channel].push(nick);
       this.sendExactToDiscord(channel, `*${nick}* has joined the channel`);
     });
 
     this.ircClient.on('part', (channel, nick, reason) => {
-      if (!this.ircStatusNotices || nick === this.nickname) return;
+      if (!this.ircStatusNotices) return;
+      // remove list of users when no longer in channel (as it will become out of date)
+      if (nick === this.nickname) {
+        delete this.channelUsers[channel];
+        return;
+      }
+      this.channelUsers[channel].splice(this.channelUsers[channel].indexOf(nick), 1);
       this.sendExactToDiscord(channel, `*${nick}* has left the channel (${reason})`);
     });
 
     this.ircClient.on('quit', (nick, reason, channels) => {
       if (!this.ircStatusNotices || nick === this.nickname) return;
       channels.forEach((channel) => {
+        const index = this.channelUsers[channel].indexOf(nick);
+        if (index === -1) return;
+        this.channelUsers[channel].splice(index, 1);
         this.sendExactToDiscord(channel, `*${nick}* has quit (${reason})`);
       });
+    });
+
+    this.ircClient.on('names', (channel, nicks) => {
+      if (!this.ircStatusNotices) return;
+      this.channelUsers[channel] = Object.keys(nicks);
     });
 
     this.ircClient.on('action', (author, to, text) => {

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -130,7 +130,7 @@ class Bot {
       if (nick === this.nickname && !this.announceSelfJoin) return;
       // self-join is announced before names (which includes own nick)
       // so don't add nick to channelUsers
-      if (nick !== this.nickname) this.channelUsers[channel].push(nick);
+      if (nick !== this.nickname) this.channelUsers[channel].add(nick);
       this.sendExactToDiscord(channel, `*${nick}* has joined the channel`);
     });
 
@@ -141,23 +141,21 @@ class Bot {
         delete this.channelUsers[channel];
         return;
       }
-      this.channelUsers[channel].splice(this.channelUsers[channel].indexOf(nick), 1);
+      this.channelUsers[channel].delete(nick);
       this.sendExactToDiscord(channel, `*${nick}* has left the channel (${reason})`);
     });
 
     this.ircClient.on('quit', (nick, reason, channels) => {
       if (!this.ircStatusNotices || nick === this.nickname) return;
       channels.forEach((channel) => {
-        const index = this.channelUsers[channel].indexOf(nick);
-        if (index === -1) return;
-        this.channelUsers[channel].splice(index, 1);
+        if (!this.channelUsers[channel].delete(nick)) return;
         this.sendExactToDiscord(channel, `*${nick}* has quit (${reason})`);
       });
     });
 
     this.ircClient.on('names', (channel, nicks) => {
       if (!this.ircStatusNotices) return;
-      this.channelUsers[channel] = Object.keys(nicks);
+      this.channelUsers[channel] = new Set(Object.keys(nicks));
     });
 
     this.ircClient.on('action', (author, to, text) => {

--- a/test/bot-events.test.js
+++ b/test/bot-events.test.js
@@ -131,7 +131,8 @@ describe('Bot Events', function () {
     // nick => '' means the user is not a special user
     const nicks = { [bot.nickname]: '', user: '', user2: '@', user3: '+' };
     bot.ircClient.emit('names', channel, nicks);
-    bot.channelUsers.should.deep.equal({ '#channel': [bot.nickname, 'user', 'user2', 'user3'] });
+    const channelNicks = new Set([bot.nickname, 'user', 'user2', 'user3']);
+    bot.channelUsers.should.deep.equal({ '#channel': channelNicks });
   });
 
   it('should send join messages to discord when config enabled', function () {
@@ -143,7 +144,8 @@ describe('Bot Events', function () {
     const text = `*${nick}* has joined the channel`;
     bot.ircClient.emit('join', channel, nick);
     bot.sendExactToDiscord.should.have.been.calledWithExactly(channel, text);
-    bot.channelUsers.should.deep.equal({ '#channel': [bot.nickname, nick] });
+    const channelNicks = new Set([bot.nickname, nick]);
+    bot.channelUsers.should.deep.equal({ '#channel': channelNicks });
   });
 
   it('should not announce itself joining by default', function () {
@@ -154,7 +156,8 @@ describe('Bot Events', function () {
     const nick = bot.nickname;
     bot.ircClient.emit('join', channel, nick);
     bot.sendExactToDiscord.should.not.have.been.called;
-    bot.channelUsers.should.deep.equal({ '#channel': [bot.nickname] });
+    const channelNicks = new Set([bot.nickname]);
+    bot.channelUsers.should.deep.equal({ '#channel': channelNicks });
   });
 
   it('should announce the bot itself when config enabled', function () {
@@ -175,13 +178,15 @@ describe('Bot Events', function () {
     const channel = '#channel';
     const nick = 'user';
     bot.ircClient.emit('names', channel, { [bot.nickname]: '', [nick]: '' });
-    bot.channelUsers.should.deep.equal({ '#channel': [bot.nickname, nick] });
+    const originalNicks = new Set([bot.nickname, nick]);
+    bot.channelUsers.should.deep.equal({ '#channel': originalNicks });
     const reason = 'Leaving';
     const text = `*${nick}* has left the channel (${reason})`;
     bot.ircClient.emit('part', channel, nick, reason);
     bot.sendExactToDiscord.should.have.been.calledWithExactly(channel, text);
     // it should remove the nickname from the channelUsers list
-    bot.channelUsers.should.deep.equal({ '#channel': [bot.nickname] });
+    const channelNicks = new Set([bot.nickname]);
+    bot.channelUsers.should.deep.equal({ '#channel': channelNicks });
   });
 
   it('should not announce itself leaving a channel', function () {
@@ -189,7 +194,8 @@ describe('Bot Events', function () {
     bot.connect();
     const channel = '#channel';
     bot.ircClient.emit('names', channel, { [bot.nickname]: '', user: '' });
-    bot.channelUsers.should.deep.equal({ '#channel': [bot.nickname, 'user'] });
+    const originalNicks = new Set([bot.nickname, 'user']);
+    bot.channelUsers.should.deep.equal({ '#channel': originalNicks });
     const reason = 'Leaving';
     bot.ircClient.emit('part', channel, bot.nickname, reason);
     bot.sendExactToDiscord.should.not.have.been.called;


### PR DESCRIPTION
Keep a list of users in each channel, using the `names` event in addition to the `join`/`part` events, so as to prevent spamming unnecessary channels when the `quit` event is raised with all channels from a server.

Fixes #213.

I'm not sure if this is a bug with node-irc (the quit event shouldn't be sent for all channels on that server, just the channels the user is in) or if it's intended behavior (the quit event is sent 'for the server', and so for all channels on it). Either way this is a workaround to make the new functionality… less spammy. I might report it there but they don't seem to have very active development.

This also rewrites a test name to make it fit into the syntax ("Bot Events should…") and reflect the new functionality: "should be possible to get the bot to announce itself joining" → "should announce the bot itself when config enabled".