### PR TITLE
Warn if a part/quit is received and no channelUsers is set

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -146,7 +146,11 @@ class Bot {
         delete this.channelUsers[channel];
         return;
       }
-      this.channelUsers[channel].delete(nick);
+      if (this.channelUsers[channel]) {
+        this.channelUsers[channel].delete(nick);
+      } else {
+        logger.warn(`No channelUsers found for ${channel} when ${nick} parted.`);
+      }
       this.sendExactToDiscord(channel, `*${nick}* has left the channel (${reason})`);
     });
 
@@ -155,6 +159,10 @@ class Bot {
       if (!this.ircStatusNotices || nick === this.nickname) return;
       channels.forEach((channelName) => {
         const channel = channelName.toLowerCase();
+        if (!this.channelUsers[channel]) {
+          logger.warn(`No channelUsers found for ${channel} when ${nick} quit, ignoring.`);
+          return;
+        }
         if (!this.channelUsers[channel].delete(nick)) return;
         this.sendExactToDiscord(channel, `*${nick}* has quit (${reason})`);
       });

--- a/test/bot-events.test.js
+++ b/test/bot-events.test.js
@@ -263,6 +263,19 @@ describe('Bot Events', function () {
     bot.sendExactToDiscord.should.not.have.been.called;
   });
 
+  it('should warn if it receives a part/quit before a names event', function () {
+    const bot = createBot({ ...config, ircStatusNotices: true });
+    bot.connect();
+    const channel = '#channel';
+    const reason = 'Leaving';
+
+    bot.ircClient.emit('part', channel, 'user1', reason);
+    bot.ircClient.emit('quit', 'user2', reason, [channel]);
+    this.warnSpy.should.have.been.calledTwice;
+    this.warnSpy.getCall(0).args.should.deep.equal([`No channelUsers found for ${channel} when user1 parted.`]);
+    this.warnSpy.getCall(1).args.should.deep.equal([`No channelUsers found for ${channel} when user2 quit, ignoring.`]);
+  });
+
   it('should not listen to discord debug messages in production', function () {
     logger.level = 'info';
     const bot = createBot();


### PR DESCRIPTION
Attempts to fix #216's crash but is unlikely to fix the underlying issue (that somehow the client isn't saving
a list of nicks in a channel, either because the server isn't sending a names event, or the node-irc library is processing it poorly, or otherwise).

I'm not sure this should be merged until a proper fix is found, but this shouldn't damage anything anyway.

I couldn't produce the actual crash on the particular server so it might be related to the particular channel in use, but this should hopefully work as a stopgap measure so the bot can be used with status messages (well, joins and probably parts) on such channels, while still alerting when weird behavior is going on.