### PR TITLE
Fix ircStatusNotices when channels are not lowercase

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -125,19 +125,24 @@ class Bot {
       this.sendToDiscord(author, to, `*${text}*`);
     });
 
-    this.ircClient.on('join', (channel, nick) => {
+    this.ircClient.on('join', (channelName, nick) => {
+      logger.debug('Received join:', channelName, nick);
       if (!this.ircStatusNotices) return;
       if (nick === this.nickname && !this.announceSelfJoin) return;
+      const channel = channelName.toLowerCase();
       // self-join is announced before names (which includes own nick)
       // so don't add nick to channelUsers
       if (nick !== this.nickname) this.channelUsers[channel].add(nick);
       this.sendExactToDiscord(channel, `*${nick}* has joined the channel`);
     });
 
-    this.ircClient.on('part', (channel, nick, reason) => {
+    this.ircClient.on('part', (channelName, nick, reason) => {
+      logger.debug('Received part:', channelName, nick, reason);
       if (!this.ircStatusNotices) return;
+      const channel = channelName.toLowerCase();
       // remove list of users when no longer in channel (as it will become out of date)
       if (nick === this.nickname) {
+        logger.debug('Deleting channelUsers as bot parted:', channel);
         delete this.channelUsers[channel];
         return;
       }
@@ -146,15 +151,19 @@ class Bot {
     });
 
     this.ircClient.on('quit', (nick, reason, channels) => {
+      logger.debug('Received quit:', nick, channels);
       if (!this.ircStatusNotices || nick === this.nickname) return;
-      channels.forEach((channel) => {
+      channels.forEach((channelName) => {
+        const channel = channelName.toLowerCase();
         if (!this.channelUsers[channel].delete(nick)) return;
         this.sendExactToDiscord(channel, `*${nick}* has quit (${reason})`);
       });
     });
 
-    this.ircClient.on('names', (channel, nicks) => {
+    this.ircClient.on('names', (channelName, nicks) => {
+      logger.debug('Received names:', channelName, nicks);
       if (!this.ircStatusNotices) return;
+      const channel = channelName.toLowerCase();
       this.channelUsers[channel] = new Set(Object.keys(nicks));
     });
 


### PR DESCRIPTION
Should fix #216, by lowercasing the channel name when it receives each event. This also adds debug messages to make it easier to see when the bot is actually receiving (and presumably processing) these events.

(When I tested it with the #NovaMC channel, it did in fact crash on master but did not on this branch.)

The added tests fail on master – the first, obviously, because master is not trying to lowercase the channel name, and the second reproduces this particular example with fake events, demonstrating the actual failure of the old code.

It may still be useful to merge #218, in case there are other circumstances that could produce this (such as a race condition for the events, which I think is possible though maybe not likely).