### PR TITLE
Allow commandCharacters to work for messages sent to Discord

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -37,24 +37,25 @@ class Bot {
     this.ircStatusNotices = options.ircStatusNotices;
     this.announceSelfJoin = options.announceSelfJoin;
 
-    this.format = options.format || {};
     // "{$keyName}" => "variableValue"
-    // nickname: discord nickname
-    // displayUsername: nickname with wrapped colors
-    // text: the (IRC-formatted) message content
+    // author/nickname: nickname of the user who sent the message
     // discordChannel: Discord channel (e.g. #general)
     // ircChannel: IRC channel (e.g. #irc)
+    // text: the (appropriately formatted) message content
+    this.format = options.format || {};
+
+    // "{$keyName}" => "variableValue"
+    // displayUsername: nickname with wrapped colors
     // attachmentURL: the URL of the attachment (only applicable in formatURLAttachment)
-    this.formatCommandPrelude = this.format.commandPrelude || 'Command sent from Discord by {$nickname}:';
     this.formatIRCText = this.format.ircText || '<{$displayUsername}> {$text}';
     this.formatURLAttachment = this.format.urlAttachment || '<{$displayUsername}> {$attachmentURL}';
 
     // "{$keyName}" => "variableValue"
-    // author: IRC nickname
-    // text: the (Discord-formatted) message content
+    // side: "Discord" or "IRC"
+    this.formatCommandPrelude = this.format.commandPrelude || 'Command sent from {$side} by {$nickname}:';
+
+    // "{$keyName}" => "variableValue"
     // withMentions: text with appropriate mentions reformatted
-    // discordChannel: Discord channel (e.g. #general)
-    // ircChannel: IRC channel (e.g. #irc)
     this.formatDiscord = this.format.discord || '**<{$author}>** {$withMentions}';
 
     // Keep track of { channel => [list, of, usernames] } for ircStatusNotices
@@ -239,6 +240,7 @@ class Bot {
       }
 
       const patternMap = {
+        author: nickname,
         nickname,
         displayUsername,
         text,
@@ -247,7 +249,9 @@ class Bot {
       };
 
       if (this.isCommandMessage(text)) {
+        patternMap.side = 'Discord';
         const prelude = Bot.substitutePattern(this.formatCommandPrelude, patternMap);
+        logger.debug('Sending command message to IRC', ircChannel, text);
         this.ircClient.say(ircChannel, prelude);
         this.ircClient.say(ircChannel, text);
       } else {
@@ -299,6 +303,23 @@ class Bot {
     // Convert text formatting (bold, italics, underscore)
     const withFormat = formatFromIRCToDiscord(text);
 
+    const patternMap = {
+      author,
+      nickname: author,
+      text: withFormat,
+      discordChannel: `#${discordChannel.name}`,
+      ircChannel: channel
+    };
+
+    if (this.isCommandMessage(text)) {
+      patternMap.side = 'IRC';
+      const prelude = Bot.substitutePattern(this.formatCommandPrelude, patternMap);
+      logger.debug('Sending command message to Discord', `#${discordChannel.name}`, text);
+      discordChannel.sendMessage(prelude);
+      discordChannel.sendMessage(text);
+      return;
+    }
+
     const withMentions = withFormat.replace(/@[^\s]+\b/g, (match) => {
       const search = match.substring(1);
       const guild = discordChannel.guild;
@@ -320,13 +341,7 @@ class Bot {
       return match;
     });
 
-    const patternMap = {
-      author,
-      text: withFormat,
-      withMentions,
-      discordChannel: `#${discordChannel.name}`,
-      ircChannel: channel
-    };
+    patternMap.withMentions = withMentions;
 
     // Add bold formatting:
     // Use custom formatting from config / default formatting with bold author


### PR DESCRIPTION
Fixes #217.

Alter the custom formatting code somewhat (to make it easier for the next change to be implemented):
- Reorganize the comments describing how to format the custom formatting options
- Make 'author' and 'nickname' synonyms in the custom formatting
- Add a 'side' parameter for commandPrelude (takes 'Discord' or 'IRC', depending on whether the message was from Discord or IRC)

Add commandCharacters support for messages sent to Discord:
- Add functionality for command messages sent in IRC to Discord, as from Discord to IRC
- Add debug messages upon sending command messages
- Add tests for the above and custom formatting of it