### PR TITLE
Add documentation for Discord channel IDs and the custom formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ First you need to create a Discord bot user, which you can do by following the i
       ["AUTH", "test", "password"]
     ],
     "channelMapping": { // Maps each Discord-channel to an IRC-channel, used to direct messages to the correct place
-      "#discord": "#irc channel-password" // Add channel keys after the channel name
+      "#discord": "#irc channel-password", // Add channel keys after the channel name
+      "1234567890": "#channel" // Use a discord channel ID instead of its name (so you can rename it or to disambiguate)
     },
     "ircOptions": { // Optional node-irc options
       "floodProtection": false, // On by default
@@ -80,6 +81,8 @@ First you need to create a Discord bot user, which you can do by following the i
 ```
 
 The `ircOptions` object is passed directly to node-irc ([available options](http://node-irc.readthedocs.org/en/latest/API.html#irc.Client)).
+
+To retrieve a discord channel ID, write `\#channel` on the relevant server – it should produce something of the form `<#1234567890>`, which you can then use in the `channelMapping` config.
 
 ## Tests
 Run the tests with:

--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ First you need to create a Discord bot user, which you can do by following the i
       "floodProtection": false, // On by default
       "floodProtectionDelay": 1000 // 500 by default
     },
+    "format": { // Optional custom formatting options
+      // Patterns, represented by {$patternName}, are replaced when sending messages
+      "commandPrelude": "Command sent by {$nickname}", // Message sent before a command
+      "ircText": "<{$displayUsername}> {$text}", // When sending a message to IRC
+      "urlAttachment": "<{$displayUsername}> {$attachmentURL}", // When sending a Discord attachment to IRC
+      "discord": "**<{$author}>** {$withMentions}" // When sending a message to Discord
+      // Other patterns that can be used:
+      // {$discordChannel} (e.g. #general)
+      // {$ircChannel} (e.g. #irc)
+    },
     "ircNickColor": false, // Gives usernames a color in IRC for better readability (on by default)
     // Makes the bot hide the username prefix for messages that start
     // with one of these characters (commands):


### PR DESCRIPTION
I think this is pretty clear from the title – it adds documentation for the new discord channel ID feature (which, as mentioned [here](https://github.com/reactiflux/discord-irc/issues/15#issuecomment-294032226), has not been clearly documented) and also the custom formatting feature.

This may not cover everything or it might be too detailed to fit into that config, in which case I'm plenty happy to move it somewhere more relevant, optionally with more details about the individual intricacies. Feel free to modify the style / phrasing (or request I do so) if you'd rather it be done otherwise – I tried to have it fit into the surrounding text, but may not have done so sufficiently.