### PR TITLE
Use webhooks to reflect irc usernames + avatars

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,15 @@ The `ircOptions` object is passed directly to node-irc ([available options](http
 
 To retrieve a discord channel ID, write `\#channel` on the relevant server – it should produce something of the form `<#1234567890>`, which you can then use in the `channelMapping` config.
 
+### Webhooks
+Webhooks allow nickname and avatar override, so messages coming from IRC will appear almost as regular Discord messages.
+
+See [here (part 1 only)](https://support.discordapp.com/hc/en-us/articles/228383668-Intro-to-Webhooks) to create a webhook for a channel.
+
+Example result:
+
+![discord-webhook](http://i.imgur.com/lNeJIUI.jpg)
+
 ## Tests
 Run the tests with:
 ```bash

--- a/README.md
+++ b/README.md
@@ -73,7 +73,11 @@ First you need to create a Discord bot user, which you can do by following the i
     "ircNickColor": false, // Gives usernames a color in IRC for better readability (on by default)
     // Makes the bot hide the username prefix for messages that start
     // with one of these characters (commands):
-    "commandCharacters": ["!", "."]
+    "commandCharacters": ["!", "."],
+    // List of webhooks per channel
+    "webhooks": {
+      "#discord": "https://discordapp.com/api/webhooks/id/token"
+    }
   }
 ]
 ```

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -34,10 +34,17 @@ class Bot {
     this.channels = _.values(options.channelMapping);
 
     this.channelMapping = {};
+    this.webhooks = {};
 
     // Remove channel passwords from the mapping and lowercase IRC channel names
     _.forOwn(options.channelMapping, (ircChan, discordChan) => {
       this.channelMapping[discordChan] = ircChan.split(' ')[0].toLowerCase();
+    });
+
+    // Extract id and token from Webhook urls
+    _.forOwn(options.webhooks, (url, chan) => {
+      const [id, token] = url.split('/').slice(-2);
+      this.webhooks[chan] = { id, token };
     });
 
     this.invertedMapping = _.invert(this.channelMapping);
@@ -47,6 +54,9 @@ class Bot {
   connect() {
     logger.debug('Connecting to IRC and Discord');
     this.discord.login(this.discordToken);
+    _.forOwn(this.webhooks, (webhook, channel) => {
+      this.webhooks[channel].client = new discord.WebhookClient(webhook.id, webhook.token);
+    });
 
     const ircOptions = {
       userName: this.nickname,
@@ -151,7 +161,9 @@ class Bot {
   sendToIRC(message) {
     const author = message.author;
     // Ignore messages sent by the bot itself:
-    if (author.id === this.discord.user.id) return;
+    if (author.id === this.discord.user.id ||
+        Object.keys(this.webhooks).some(chan => this.webhooks[chan].id === author.id)
+      ) return;
 
     const channelName = `#${message.channel.name}`;
     const ircChannel = this.channelMapping[channelName];
@@ -189,6 +201,16 @@ class Bot {
     }
   }
 
+  getDiscordAvatar(nick) {
+    const user = this.discord.guilds.first().members.find(
+      member => member.user.username.toLowerCase() === nick.toLowerCase()
+    );
+    if (user) {
+      return user.user.avatarURL;
+    }
+    return null;
+  }
+
   sendToDiscord(author, channel, text) {
     const discordChannelName = this.invertedMapping[channel.toLowerCase()];
     if (discordChannelName) {
@@ -200,6 +222,16 @@ class Bot {
       if (!discordChannel) {
         logger.info('Tried to send a message to a channel the bot isn\'t in: ',
           discordChannelName);
+        return;
+      }
+      if (this.webhooks[discordChannelName]) {
+        this.webhooks[discordChannelName].client.sendMessage(
+          text,
+          {
+            username: author,
+            text,
+            avatarURL: this.getDiscordAvatar(author)
+          }).catch(logger.error);
         return;
       }
 

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -367,7 +367,7 @@ class Bot {
         }
         const nickLowerCase = nick.toLowerCase();
         return member.user.username.toLowerCase() === nickLowerCase
-          || member.nickname.toLowerCase() === nickLowerCase;
+          || (member.nickname && member.nickname.toLowerCase() === nickLowerCase);
       };
 
     // Try to find exact matching case

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -322,6 +322,8 @@ class Bot {
         .find('name', discordChannelName.slice(1)) : this.discord.channels.get(discordChannelName);
 
       if (!discordChannel) {
+        logger.info('Tried to send a message to a channel the bot isn\'t in: ',
+          discordChannelName);
         return null;
       }
       return discordChannel;
@@ -337,13 +339,15 @@ class Bot {
         return webhook;
       }
     }
-    logger.info('Tried to send a message to a channel the bot isn\'t in or without webhook attached: ',
-      discordChannelName);
     return null;
   }
 
   sendToDiscord(author, channel, text) {
     const discordChannel = this.findDiscordChannel(channel);
+    if (!discordChannel) {
+      return;
+    }
+
 
     // Convert text formatting (bold, italics, underscore)
     const withFormat = formatFromIRCToDiscord(text);
@@ -369,6 +373,20 @@ class Bot {
       return match;
     });
 
+    // Webhooks first
+    const webhook = this.findWebhook(channel);
+    if (webhook) {
+      logger.debug('Sending message to Discord via webhook', withMentions, channel, '->', `#${discordChannel.name}`);
+      webhook.client.sendMessage(
+        withMentions,
+        {
+          username: author,
+          text,
+          avatarURL: this.getDiscordAvatar(author)
+        }).catch(logger.error);
+      return;
+    }
+
     const patternMap = {
       author,
       text: withFormat,
@@ -381,19 +399,6 @@ class Bot {
     // Use custom formatting from config / default formatting with bold author
     const withAuthor = Bot.substitutePattern(this.formatDiscord, patternMap);
     logger.debug('Sending message to Discord', withAuthor, channel, '->', `#${discordChannel.name}`);
-    if (!discordChannel) {
-      const webhook = this.findWebhook(channel);
-      if (webhook) {
-        webhook.client.sendMessage(
-          withAuthor,
-          {
-            username: author,
-            text,
-            avatarURL: this.getDiscordAvatar(author)
-          }).catch(logger.error);
-      }
-      return;
-    }
     discordChannel.sendMessage(withAuthor);
   }
 

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -344,10 +344,7 @@ class Bot {
 
   sendToDiscord(author, channel, text) {
     const discordChannel = this.findDiscordChannel(channel);
-    if (!discordChannel) {
-      return;
-    }
-
+    if (!discordChannel) return;
 
     // Convert text formatting (bold, italics, underscore)
     const withFormat = formatFromIRCToDiscord(text);

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -323,11 +323,9 @@ class Bot {
   }
 
   getDiscordAvatar(nick) {
-    const user = this.discord.guilds.first().members.find(
-      member => member.user.username.toLowerCase() === nick.toLowerCase()
-    );
+    const user = this.discord.users.find('username', nick);
     if (user) {
-      return user.user.avatarURL;
+      return user.avatarURL;
     }
     return null;
   }

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -361,13 +361,13 @@ class Bot {
   getDiscordAvatar(nick, channel) {
     const guildMembers = this.findDiscordChannel(channel).guild.members;
     const findByNicknameOrUsername = caseSensitive =>
-      (value) => {
+      (member) => {
         if (caseSensitive) {
-          return value.username === nick || value.nickname === nick;
+          return member.user.username === nick || member.nickname === nick;
         }
         const nickLowerCase = nick.toLowerCase();
-        return value.username.toLowerCase() === nickLowerCase
-          || value.nickname.toLowerCase() === nickLowerCase;
+        return member.user.username.toLowerCase() === nickLowerCase
+          || member.nickname.toLowerCase() === nickLowerCase;
       };
 
     // Try to find exact matching case
@@ -380,7 +380,7 @@ class Bot {
 
     // No matching user or more than one => no avatar
     if (users && users.size === 1) {
-      return users.first().avatarURL;
+      return users.first().user.avatarURL;
     }
     return null;
   }

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -270,7 +270,7 @@ class Bot {
     // Ignore messages sent by the bot itself:
     if (author.id === this.discord.user.id ||
         Object.keys(this.webhooks).some(chan => this.webhooks[chan].id === author.id)
-      ) return;
+    ) return;
 
     const channelName = `#${message.channel.name}`;
     const ircChannel = this.channelMapping[message.channel.id] ||
@@ -329,14 +329,6 @@ class Bot {
     }
   }
 
-  getDiscordAvatar(nick) {
-    const user = this.discord.users.find('username', nick);
-    if (user) {
-      return user.avatarURL;
-    }
-    return null;
-  }
-
   findDiscordChannel(ircChannel) {
     const discordChannelName = this.invertedMapping[ircChannel.toLowerCase()];
     if (discordChannelName) {
@@ -362,6 +354,33 @@ class Bot {
       if (webhook) {
         return webhook;
       }
+    }
+    return null;
+  }
+
+  getDiscordAvatar(nick, channel) {
+    const guildMembers = this.findDiscordChannel(channel).guild.members;
+    const findByNicknameOrUsername = caseSensitive =>
+      (value) => {
+        if (caseSensitive) {
+          return value.username === nick || value.nickname === nick;
+        }
+        const nickLowerCase = nick.toLowerCase();
+        return value.username.toLowerCase() === nickLowerCase
+          || value.nickname.toLowerCase() === nickLowerCase;
+      };
+
+    // Try to find exact matching case
+    let users = guildMembers.filter(findByNicknameOrUsername(false));
+
+    // Now let's search case insensitive.
+    if (!users) {
+      users = guildMembers.filter(findByNicknameOrUsername(true));
+    }
+
+    // No matching user or more than one => no avatar
+    if (users && users.size === 1) {
+      return users.first().avatarURL;
     }
     return null;
   }
@@ -430,7 +449,7 @@ class Bot {
         {
           username: author,
           text,
-          avatarURL: this.getDiscordAvatar(author)
+          avatarURL: this.getDiscordAvatar(author, channel)
         }).catch(logger.error);
       return;
     }

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -36,6 +36,7 @@ class Bot {
     this.channels = _.values(options.channelMapping);
     this.ircStatusNotices = options.ircStatusNotices;
     this.announceSelfJoin = options.announceSelfJoin;
+    this.webhookOptions = options.webhooks;
 
     // "{$keyName}" => "variableValue"
     // author/nickname: nickname of the user who sent the message
@@ -72,12 +73,6 @@ class Bot {
       this.channelMapping[discordChan] = ircChan.split(' ')[0].toLowerCase();
     });
 
-    // Extract id and token from Webhook urls
-    _.forOwn(options.webhooks, (url, chan) => {
-      const [id, token] = url.split('/').slice(-2);
-      this.webhooks[chan] = { id, token };
-    });
-
     this.invertedMapping = _.invert(this.channelMapping);
     this.autoSendCommands = options.autoSendCommands || [];
   }
@@ -85,8 +80,15 @@ class Bot {
   connect() {
     logger.debug('Connecting to IRC and Discord');
     this.discord.login(this.discordToken);
-    _.forOwn(this.webhooks, (webhook, channel) => {
-      this.webhooks[channel].client = new discord.WebhookClient(webhook.id, webhook.token);
+
+    // Extract id and token from Webhook urls and connect.
+    _.forOwn(this.webhookOptions, (url, channel) => {
+      const [id, token] = url.split('/').slice(-2);
+      const client = new discord.WebhookClient(id, token);
+      this.webhooks[channel] = {
+        id,
+        client
+      };
     });
 
     const ircOptions = {
@@ -269,7 +271,7 @@ class Bot {
     const author = message.author;
     // Ignore messages sent by the bot itself:
     if (author.id === this.discord.user.id ||
-        Object.keys(this.webhooks).some(chan => this.webhooks[chan].id === author.id)
+        Object.keys(this.webhooks).some(channel => this.webhooks[channel].id === author.id)
     ) return;
 
     const channelName = `#${message.channel.name}`;
@@ -349,13 +351,7 @@ class Bot {
 
   findWebhook(ircChannel) {
     const discordChannelName = this.invertedMapping[ircChannel.toLowerCase()];
-    if (discordChannelName) {
-      const webhook = this.webhooks[discordChannelName];
-      if (webhook) {
-        return webhook;
-      }
-    }
-    return null;
+    return discordChannelName && this.webhooks[discordChannelName];
   }
 
   getDiscordAvatar(nick, channel) {
@@ -444,13 +440,12 @@ class Bot {
     const webhook = this.findWebhook(channel);
     if (webhook) {
       logger.debug('Sending message to Discord via webhook', withMentions, channel, '->', `#${discordChannel.name}`);
-      webhook.client.sendMessage(
-        withMentions,
-        {
-          username: author,
-          text,
-          avatarURL: this.getDiscordAvatar(author, channel)
-        }).catch(logger.error);
+      const avatarURL = this.getDiscordAvatar(author, channel);
+      webhook.client.sendMessage(withMentions, {
+        username: author,
+        text,
+        avatarURL
+      }).catch(logger.error);
       return;
     }
 

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -371,11 +371,11 @@ class Bot {
       };
 
     // Try to find exact matching case
-    let users = guildMembers.filter(findByNicknameOrUsername(false));
+    let users = guildMembers.filter(findByNicknameOrUsername(true));
 
     // Now let's search case insensitive.
-    if (!users) {
-      users = guildMembers.filter(findByNicknameOrUsername(true));
+    if (users.size === 0) {
+      users = guildMembers.filter(findByNicknameOrUsername(false));
     }
 
     // No matching user or more than one => no avatar

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "check-env": "1.2.0",
     "commander": "2.9.0",
-    "discord.js": "git://github.com/hydrabolt/discord.js.git",
+    "discord.js": "11.1.0",
     "irc": "0.5.2",
     "lodash": "^4.17.4",
     "strip-json-comments": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "check-env": "1.2.0",
     "commander": "2.9.0",
-    "discord.js": "11.0.0",
+    "discord.js": "git://github.com/hydrabolt/discord.js.git",
     "irc": "0.5.2",
     "lodash": "^4.17.4",
     "strip-json-comments": "2.0.1",

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -817,7 +817,6 @@ describe('Bot', function () {
 
   it('should extract id and token from webhook urls', function () {
     this.bot.webhooks['#withwebhook'].id.should.equal('id');
-    this.bot.webhooks['#withwebhook'].token.should.equal('token');
   });
 
   it('should find the matching webhook when it exists', function () {

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -836,37 +836,55 @@ describe('Bot', function () {
     const newConfig = { ...config, webhooks: { '#discord': 'https://discordapp.com/api/webhooks/id/token' } };
     const bot = new Bot(newConfig);
     bot.connect();
-    const user = new discord.User(this.bot.discord, { username: 'Nick', avatar: 'avatarURL' });
-    this.guild.members.set(1, { user, nickname: 'Different' });
-    this.bot.getDiscordAvatar('Nick', '#irc').should.equal('/avatars/<@undefined>/avatarURL.png?size=2048');
+    const userObj = { id: 123, username: 'Nick', avatar: 'avatarURL' };
+    const memberObj = { nickname: 'Different' };
+    this.addUser(userObj, memberObj);
+    this.bot.getDiscordAvatar('Nick', '#irc').should.equal('/avatars/123/avatarURL.png?size=2048');
   });
 
   it('should find a matching username, case insensitive, when looking for an avatar', function () {
     const newConfig = { ...config, webhooks: { '#discord': 'https://discordapp.com/api/webhooks/id/token' } };
     const bot = new Bot(newConfig);
     bot.connect();
-    const user = new discord.User(this.bot.discord, { username: 'nick', avatar: 'avatarURL' });
-    this.guild.members.set(1, { user, nickname: 'Different' });
-    this.bot.getDiscordAvatar('Nick', '#irc').should.equal('/avatars/<@undefined>/avatarURL.png?size=2048');
+    const userObj = { id: 124, username: 'nick', avatar: 'avatarURL' };
+    const memberObj = { nickname: 'Different' };
+    this.addUser(userObj, memberObj);
+    this.bot.getDiscordAvatar('Nick', '#irc').should.equal('/avatars/124/avatarURL.png?size=2048');
   });
 
   it('should find a matching nickname, case sensitive, when looking for an avatar', function () {
     const newConfig = { ...config, webhooks: { '#discord': 'https://discordapp.com/api/webhooks/id/token' } };
     const bot = new Bot(newConfig);
     bot.connect();
-    const user = new discord.User(this.bot.discord, { username: 'Nick', avatar: 'avatarURL' });
-    this.guild.members.set(1, { user, nickname: 'Different' });
-    this.bot.getDiscordAvatar('Different', '#irc').should.equal('/avatars/<@undefined>/avatarURL.png?size=2048');
+    const userObj = { id: 125, username: 'Nick', avatar: 'avatarURL' };
+    const memberObj = { nickname: 'Different' };
+    this.addUser(userObj, memberObj);
+    this.bot.getDiscordAvatar('Different', '#irc').should.equal('/avatars/125/avatarURL.png?size=2048');
   });
 
   it('should not return an avatar with two matching usernames when looking for an avatar', function () {
     const newConfig = { ...config, webhooks: { '#discord': 'https://discordapp.com/api/webhooks/id/token' } };
     const bot = new Bot(newConfig);
     bot.connect();
-    const user1 = new discord.User(this.bot.discord, { username: 'common', avatar: 'avatarURL' });
-    const user2 = new discord.User(this.bot.discord, { username: 'Nick', avatar: 'avatarURL' });
-    this.guild.members.set(1, { user: user1, nickname: 'Different' });
-    this.guild.members.set(2, { user: user2, nickname: 'common' });
+    const userObj1 = { id: 126, username: 'common', avatar: 'avatarURL' };
+    const userObj2 = { id: 127, username: 'Nick', avatar: 'avatarURL' };
+    const memberObj1 = { nickname: 'Different' };
+    const memberObj2 = { nickname: 'common' };
+    this.addUser(userObj1, memberObj1);
+    this.addUser(userObj2, memberObj2);
     chai.should().equal(this.bot.getDiscordAvatar('common', '#irc'), null);
+  });
+
+  it('should not return an avatar when no users match and should handle lack of nickname, when looking for an avatar', function () {
+    const newConfig = { ...config, webhooks: { '#discord': 'https://discordapp.com/api/webhooks/id/token' } };
+    const bot = new Bot(newConfig);
+    bot.connect();
+    const userObj1 = { id: 128, username: 'common', avatar: 'avatarURL' };
+    const userObj2 = { id: 129, username: 'Nick', avatar: 'avatarURL' };
+    const memberObj1 = {};
+    const memberObj2 = { nickname: 'common' };
+    this.addUser(userObj1, memberObj1);
+    this.addUser(userObj2, memberObj2);
+    chai.should().equal(this.bot.getDiscordAvatar('nonexistent', '#irc'), null);
   });
 });

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -413,4 +413,13 @@ describe('Bot', function () {
     this.bot.sendToDiscord(username, '#irc', text);
     this.sendMessageStub.should.have.been.calledWith(expected);
   });
+
+  it('should create webhooks clients for each webhook url in the config', function () {
+    this.bot.webhooks.should.have.property('#irc');
+  });
+
+  it('should extract id and token from webhook urls', function () {
+    this.bot.webhooks['#irc'].id.should.equal('id');
+    this.bot.webhooks['#irc'].token.should.equal('token');
+  });
 });

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -832,11 +832,40 @@ describe('Bot', function () {
     this.sendWebhookMessageStub.should.have.been.called;
   });
 
-  it('should search for the user\'s avatar when sending via webhook', function () {
+  it('should find a matching username, case sensitive, when looking for an avatar', function () {
     const newConfig = { ...config, webhooks: { '#discord': 'https://discordapp.com/api/webhooks/id/token' } };
     const bot = new Bot(newConfig);
     bot.connect();
-    bot.sendToDiscord('nick', '#irc', 'text');
-    this.findUserStub.should.have.been.called;
+    bot.sendToDiscord('Nick', '#irc', 'text');
+    this.guild.members.set(1, { username: 'Nick', nickname: 'Different', avatarURL: 'avatarURL' });
+    this.bot.getDiscordAvatar('nick', '#irc').should.equal('avatarURL');
+  });
+
+  it('should find a matching username, case insensitive, when looking for an avatar', function () {
+    const newConfig = { ...config, webhooks: { '#discord': 'https://discordapp.com/api/webhooks/id/token' } };
+    const bot = new Bot(newConfig);
+    bot.connect();
+    bot.sendToDiscord('Nick', '#irc', 'text');
+    this.guild.members.set(1, { username: 'nick', nickname: 'Different', avatarURL: 'avatarURL' });
+    this.bot.getDiscordAvatar('nick', '#irc').should.equal('avatarURL');
+  });
+
+  it('should find a matching nickname, case sensitive, when looking for an avatar', function () {
+    const newConfig = { ...config, webhooks: { '#discord': 'https://discordapp.com/api/webhooks/id/token' } };
+    const bot = new Bot(newConfig);
+    bot.connect();
+    bot.sendToDiscord('Different', '#irc', 'text');
+    this.guild.members.set(1, { username: 'Nick', nickname: 'Different', avatarURL: 'avatarURL' });
+    this.bot.getDiscordAvatar('nick', '#irc').should.equal('avatarURL');
+  });
+
+  it('should not return an avatar with two matching usernames when looking for an avatar', function () {
+    const newConfig = { ...config, webhooks: { '#discord': 'https://discordapp.com/api/webhooks/id/token' } };
+    const bot = new Bot(newConfig);
+    bot.connect();
+    bot.sendToDiscord('common', '#irc', 'text');
+    this.guild.members.set(1, { username: 'common', nickname: 'Different', avatarURL: 'avatarURL' });
+    this.guild.members.set(2, { username: 'Nick', nickname: 'common', avatarURL: 'avatarURL' });
+    chai.should().equal(this.bot.getDiscordAvatar('common', '#irc'), null);
   });
 });

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -846,7 +846,7 @@ describe('Bot', function () {
     this.sendMessageStub.getCall(0).args.should.deep.equal([msg]);
   });
 
-    it('should create webhooks clients for each webhook url in the config', function () {
+  it('should create webhooks clients for each webhook url in the config', function () {
     this.bot.webhooks.should.have.property('#withwebhook');
   });
 
@@ -867,9 +867,11 @@ describe('Bot', function () {
     this.sendWebhookMessageStub.should.have.been.called;
   });
 
-  it('should find the user\'s avatar when the irc nick is also a discord username', function () {
-    const testUser = new discord.User(this.bot.discord, { username: 'avatarUser', id: '123', avatar: '123' });
-    this.findUserStub.withArgs('username', testUser.username).returns(testUser);
-    this.bot.getDiscordAvatar('avatarUser').should.not.equal(null);
+  it('should search for the user\'s avatar when sending via webhook', function () {
+    const newConfig = { ...config, webhooks: { '#discord': 'https://discordapp.com/api/webhooks/id/token' } };
+    const bot = new Bot(newConfig);
+    bot.connect();
+    bot.sendToDiscord('nick', '#irc', 'text');
+    this.findUserStub.should.have.been.called;
   });
 });

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -836,32 +836,37 @@ describe('Bot', function () {
     const newConfig = { ...config, webhooks: { '#discord': 'https://discordapp.com/api/webhooks/id/token' } };
     const bot = new Bot(newConfig);
     bot.connect();
-    this.guild.members.set(1, { username: 'Nick', nickname: 'Different', avatarURL: 'avatarURL' });
-    this.bot.getDiscordAvatar('Nick', '#irc').should.equal('avatarURL');
+    const user = new discord.User(this.bot.discord, { username: 'Nick', avatar: 'avatarURL' });
+    this.guild.members.set(1, { user, nickname: 'Different' });
+    this.bot.getDiscordAvatar('Nick', '#irc').should.equal('/avatars/<@undefined>/avatarURL.png?size=2048');
   });
 
   it('should find a matching username, case insensitive, when looking for an avatar', function () {
     const newConfig = { ...config, webhooks: { '#discord': 'https://discordapp.com/api/webhooks/id/token' } };
     const bot = new Bot(newConfig);
     bot.connect();
-    this.guild.members.set(1, { username: 'nick', nickname: 'Different', avatarURL: 'avatarURL' });
-    this.bot.getDiscordAvatar('Nick', '#irc').should.equal('avatarURL');
+    const user = new discord.User(this.bot.discord, { username: 'nick', avatar: 'avatarURL' });
+    this.guild.members.set(1, { user, nickname: 'Different' });
+    this.bot.getDiscordAvatar('Nick', '#irc').should.equal('/avatars/<@undefined>/avatarURL.png?size=2048');
   });
 
   it('should find a matching nickname, case sensitive, when looking for an avatar', function () {
     const newConfig = { ...config, webhooks: { '#discord': 'https://discordapp.com/api/webhooks/id/token' } };
     const bot = new Bot(newConfig);
     bot.connect();
-    this.guild.members.set(1, { username: 'Nick', nickname: 'Different', avatarURL: 'avatarURL' });
-    this.bot.getDiscordAvatar('Different', '#irc').should.equal('avatarURL');
+    const user = new discord.User(this.bot.discord, { username: 'Nick', avatar: 'avatarURL' });
+    this.guild.members.set(1, { user, nickname: 'Different' });
+    this.bot.getDiscordAvatar('Different', '#irc').should.equal('/avatars/<@undefined>/avatarURL.png?size=2048');
   });
 
   it('should not return an avatar with two matching usernames when looking for an avatar', function () {
     const newConfig = { ...config, webhooks: { '#discord': 'https://discordapp.com/api/webhooks/id/token' } };
     const bot = new Bot(newConfig);
     bot.connect();
-    this.guild.members.set(1, { username: 'common', nickname: 'Different', avatarURL: 'avatarURL' });
-    this.guild.members.set(2, { username: 'Nick', nickname: 'common', avatarURL: 'avatarURL' });
+    const user1 = new discord.User(this.bot.discord, { username: 'common', avatar: 'avatarURL' });
+    const user2 = new discord.User(this.bot.discord, { username: 'Nick', avatar: 'avatarURL' });
+    this.guild.members.set(1, { user: user1, nickname: 'Different' });
+    this.guild.members.set(2, { user: user2, nickname: 'common' });
     chai.should().equal(this.bot.getDiscordAvatar('common', '#irc'), null);
   });
 });

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -836,34 +836,30 @@ describe('Bot', function () {
     const newConfig = { ...config, webhooks: { '#discord': 'https://discordapp.com/api/webhooks/id/token' } };
     const bot = new Bot(newConfig);
     bot.connect();
-    bot.sendToDiscord('Nick', '#irc', 'text');
     this.guild.members.set(1, { username: 'Nick', nickname: 'Different', avatarURL: 'avatarURL' });
-    this.bot.getDiscordAvatar('nick', '#irc').should.equal('avatarURL');
+    this.bot.getDiscordAvatar('Nick', '#irc').should.equal('avatarURL');
   });
 
   it('should find a matching username, case insensitive, when looking for an avatar', function () {
     const newConfig = { ...config, webhooks: { '#discord': 'https://discordapp.com/api/webhooks/id/token' } };
     const bot = new Bot(newConfig);
     bot.connect();
-    bot.sendToDiscord('Nick', '#irc', 'text');
     this.guild.members.set(1, { username: 'nick', nickname: 'Different', avatarURL: 'avatarURL' });
-    this.bot.getDiscordAvatar('nick', '#irc').should.equal('avatarURL');
+    this.bot.getDiscordAvatar('Nick', '#irc').should.equal('avatarURL');
   });
 
   it('should find a matching nickname, case sensitive, when looking for an avatar', function () {
     const newConfig = { ...config, webhooks: { '#discord': 'https://discordapp.com/api/webhooks/id/token' } };
     const bot = new Bot(newConfig);
     bot.connect();
-    bot.sendToDiscord('Different', '#irc', 'text');
     this.guild.members.set(1, { username: 'Nick', nickname: 'Different', avatarURL: 'avatarURL' });
-    this.bot.getDiscordAvatar('nick', '#irc').should.equal('avatarURL');
+    this.bot.getDiscordAvatar('Different', '#irc').should.equal('avatarURL');
   });
 
   it('should not return an avatar with two matching usernames when looking for an avatar', function () {
     const newConfig = { ...config, webhooks: { '#discord': 'https://discordapp.com/api/webhooks/id/token' } };
     const bot = new Bot(newConfig);
     bot.connect();
-    bot.sendToDiscord('common', '#irc', 'text');
     this.guild.members.set(1, { username: 'common', nickname: 'Different', avatarURL: 'avatarURL' });
     this.guild.members.set(2, { username: 'Nick', nickname: 'common', avatarURL: 'avatarURL' });
     chai.should().equal(this.bot.getDiscordAvatar('common', '#irc'), null);

--- a/test/fixtures/single-test-config.json
+++ b/test/fixtures/single-test-config.json
@@ -10,5 +10,8 @@
   "channelMapping": {
     "#discord": "#irc channelKey",
     "#notinchannel": "#otherIRC"
+  },
+  "webhooks": {
+    "#irc": "https://discordapp.com/api/webhooks/id/token"
   }
 }

--- a/test/fixtures/single-test-config.json
+++ b/test/fixtures/single-test-config.json
@@ -10,9 +10,10 @@
   "channelMapping": {
     "#discord": "#irc channelKey",
     "#notinchannel": "#otherIRC",
-    "1234": "#channelforid"
+    "1234": "#channelforid",
+    "#withwebhook": "#ircwebhook"
   },
   "webhooks": {
-    "#irc": "https://discordapp.com/api/webhooks/id/token"
+    "#withwebhook": "https://discordapp.com/api/webhooks/id/token"
   }
 }

--- a/test/stubs/discord-stub.js
+++ b/test/stubs/discord-stub.js
@@ -19,6 +19,11 @@ export default function createDiscordStub(sendMessageStub, findUserStub, findRol
       this.users = {
         find: findUserStub
       };
+      this.options = {
+        http: {
+          host: 'host'
+        }
+      };
     }
 
     getChannel(key, value) {

--- a/test/stubs/discord-stub.js
+++ b/test/stubs/discord-stub.js
@@ -37,7 +37,8 @@ export default function createDiscordStub(sendMessageStub, findUserStub, findRol
         guild: {
           members: {
             find: findUserStub,
-            get: findUserStub
+            get: findUserStub,
+            filter: findUserStub
           },
           roles: {
             find: findRoleStub,

--- a/test/stubs/discord-stub.js
+++ b/test/stubs/discord-stub.js
@@ -11,6 +11,11 @@ export default function createDiscordStub(sendStub, guild, discordUsers) {
         id: 'testid'
       };
       this.channels = this.guildChannels();
+      this.options = {
+        http: {
+          cdn: ''
+        }
+      };
 
       this.users = discordUsers;
     }

--- a/test/stubs/webhook-stub.js
+++ b/test/stubs/webhook-stub.js
@@ -1,0 +1,14 @@
+/* eslint-disable class-methods-use-this */
+export default function createWebhookStub(sendWebhookMessage) {
+  return class WebhookStub {
+    constructor(id, token) {
+      this.id = id;
+      this.token = token;
+    }
+
+    sendMessage() {
+      sendWebhookMessage();
+      return new Promise(() => {});
+    }
+  };
+}


### PR DESCRIPTION
This fixes #128 

The discord bot gets renamed with the irc nickname, and use the account avatar if there's a matching username in the room.

![discord](https://cloud.githubusercontent.com/assets/707985/25613972/65447d68-2f30-11e7-8d3a-ccfd5c60438c.png)
