### PR TITLE
Add `ircPreventMention` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ First you need to create a Discord bot user, which you can do by following the i
       // {$ircChannel} (e.g. #irc)
     },
     "ircNickColor": false, // Gives usernames a color in IRC for better readability (on by default)
+    "ircPreventMention": false, // Prevents users of both IRC and Discord from being mentioned in IRC when they speak in Discord (on by default)
     // Makes the bot hide the username prefix for messages that start
     // with one of these characters (commands):
     "commandCharacters": ["!", "."],

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -280,7 +280,7 @@ class Bot {
       
       if (this.ircNickColor) {
         const colorIndex = (nickname.charCodeAt(0) + nickname.length) % NICK_COLORS.length;
-        displayUsername = irc.colors.wrap(NICK_COLORS[colorIndex], nickname);
+        displayUsername = irc.colors.wrap(NICK_COLORS[colorIndex], displayUsername);
       }
 
       const patternMap = {

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -275,9 +275,9 @@ class Bot {
       if (this.ircPreventMention) {
         // Prevent users of both IRC and Discord from
         // being mentioned in IRC when they talk in Discord.
-        displayUsername = displayUsername.slice(0, 1) + "\u200B" + displayUsername.slice(1);
+        displayUsername = `${displayUsername.slice(0, 1)}\u200B${displayUsername.slice(1)}`;
       }
-      
+
       if (this.ircNickColor) {
         const colorIndex = (nickname.charCodeAt(0) + nickname.length) % NICK_COLORS.length;
         displayUsername = irc.colors.wrap(NICK_COLORS[colorIndex], displayUsername);

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -33,7 +33,7 @@ class Bot {
     this.discordToken = options.discordToken;
     this.commandCharacters = options.commandCharacters || [];
     this.ircNickColor = options.ircNickColor !== false; // default to true
-    this.ircPreventMention = options.ircPreventMention !== false; // default to true
+    this.ircPreventMention = options.ircPreventMention === true; // default: false
     this.channels = _.values(options.channelMapping);
     this.ircStatusNotices = options.ircStatusNotices;
     this.announceSelfJoin = options.announceSelfJoin;

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -33,6 +33,7 @@ class Bot {
     this.discordToken = options.discordToken;
     this.commandCharacters = options.commandCharacters || [];
     this.ircNickColor = options.ircNickColor !== false; // default to true
+    this.ircPreventMention = options.ircPreventMention !== false; // default to true
     this.channels = _.values(options.channelMapping);
     this.ircStatusNotices = options.ircStatusNotices;
     this.announceSelfJoin = options.announceSelfJoin;
@@ -270,6 +271,13 @@ class Bot {
       const nickname = Bot.getDiscordNicknameOnServer(author, fromGuild);
       let text = this.parseText(message);
       let displayUsername = nickname;
+
+      if (this.ircPreventMention) {
+        // Prevent users of both IRC and Discord from
+        // being mentioned in IRC when they talk in Discord.
+        displayUsername = displayUsername.slice(0, 1) + "\u200B" + displayUsername.slice(1);
+      }
+      
       if (this.ircNickColor) {
         const colorIndex = (nickname.charCodeAt(0) + nickname.length) % NICK_COLORS.length;
         displayUsername = irc.colors.wrap(NICK_COLORS[colorIndex], nickname);


### PR DESCRIPTION
I have the same username on both Discord and IRC. If I write a message in Discord, I receive a nickalert (a "notification", or a "mention") in IRC, which can be very annoying. This PR adds an option (defaults to "on") to prevent that from happening.

By inserting any zero width character (in this pull request, I use a zero width space) somewhere in the printed username you can prevent a nickalert from occurring, with the name looking exactly the same.

For example, with username `john`, I slice `j`, add a zero-width-space, and add `ohn` to the end. This looks like `john`, but is actually `j?ohn` where `?` is the zero width character. 

For usernames that are one character long, the zero width character is at the end of the username (the code does not crash). Depending on IRC client settings, this may or may not notify the client.

The final commit is required so that `ircNickColor` does not overwrite the `displayUsername` change earlier on by `ircPreventMention`. Colours will remain the same as the code that generates the colour still uses `nickname`.

I've actually tested functionality, and only authored it in the GitHub interface because it's easier than using Vim on my server!