### PR TITLE
Translate custom emoji references from IRC to Discord

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -371,6 +371,14 @@ class Bot {
       }
 
       return match;
+    }).replace(/:(\w+):/g, (match, ident) => {
+      const guild = discordChannel.guild;
+      const emoji = guild.emojis.find(x => x.name === ident && x.requiresColons);
+      if (emoji) {
+        return `<:${emoji.identifier}>`; // identifier = name + ":" + id
+      }
+
+      return match;
     });
 
     patternMap.withMentions = withMentions;

--- a/test/stubs/discord-stub.js
+++ b/test/stubs/discord-stub.js
@@ -2,7 +2,8 @@
 import events from 'events';
 import sinon from 'sinon';
 
-export default function createDiscordStub(sendMessageStub, findUserStub, findRoleStub) {
+export default function createDiscordStub(sendMessageStub, findUserStub, findRoleStub,
+  findEmojiStub) {
   return class DiscordStub extends events.EventEmitter {
     constructor() {
       super();
@@ -36,6 +37,9 @@ export default function createDiscordStub(sendMessageStub, findUserStub, findRol
           roles: {
             find: findRoleStub,
             get: findRoleStub
+          },
+          emojis: {
+            find: findEmojiStub
           }
         }
       };


### PR DESCRIPTION
When an IRC user uses a custom emoji reference (e.g. :testemoji:), it should be translated into the actual
emoji for Discord users, instead of appearing in plain text.

This also adds tests to ensure other emoji-like phrases do not get converted or cause the bot to crash.

(Discord users enter something such as `:testemoji:`, which gets converted into e.g. `<:testemoji:987654321>` – we already translate this to IRC, stripping the angle brackets and extra digits, but don't translate the other way as I would expect.)

Addresses issue #250.