### PR TITLE
Use ircClient.nick instead of nickname when guarding against events for current nick

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -144,11 +144,11 @@ class Bot {
     this.ircClient.on('join', (channelName, nick) => {
       logger.debug('Received join:', channelName, nick);
       if (!this.ircStatusNotices) return;
-      if (nick === this.nickname && !this.announceSelfJoin) return;
+      if (nick === this.ircClient.nick && !this.announceSelfJoin) return;
       const channel = channelName.toLowerCase();
       // self-join is announced before names (which includes own nick)
       // so don't add nick to channelUsers
-      if (nick !== this.nickname) this.channelUsers[channel].add(nick);
+      if (nick !== this.ircClient.nick) this.channelUsers[channel].add(nick);
       this.sendExactToDiscord(channel, `*${nick}* has joined the channel`);
     });
 
@@ -157,7 +157,7 @@ class Bot {
       if (!this.ircStatusNotices) return;
       const channel = channelName.toLowerCase();
       // remove list of users when no longer in channel (as it will become out of date)
-      if (nick === this.nickname) {
+      if (nick === this.ircClient.nick) {
         logger.debug('Deleting channelUsers as bot parted:', channel);
         delete this.channelUsers[channel];
         return;
@@ -172,7 +172,7 @@ class Bot {
 
     this.ircClient.on('quit', (nick, reason, channels) => {
       logger.debug('Received quit:', nick, channels);
-      if (!this.ircStatusNotices || nick === this.nickname) return;
+      if (!this.ircStatusNotices || nick === this.ircClient.nick) return;
       channels.forEach((channelName) => {
         const channel = channelName.toLowerCase();
         if (!this.channelUsers[channel]) {

--- a/test/bot-events.test.js
+++ b/test/bot-events.test.js
@@ -305,6 +305,18 @@ describe('Bot Events', function () {
     this.warnSpy.getCall(1).args.should.deep.equal([`No channelUsers found for ${channel} when user2 quit, ignoring.`]);
   });
 
+  it('should not crash if it uses a different name from config', function () {
+    // this can happen when a user with the same name is already connected
+    const bot = createBot({ ...config, nickname: 'testbot' });
+    bot.connect();
+    const newName = 'testbot1';
+    bot.ircClient.nick = newName;
+    function wrap() {
+      bot.ircClient.emit('join', '#channel', newName);
+    }
+    (wrap).should.not.throw;
+  });
+
   it('should not listen to discord debug messages in production', function () {
     logger.level = 'info';
     const bot = createBot();

--- a/test/stubs/irc-client-stub.js
+++ b/test/stubs/irc-client-stub.js
@@ -1,5 +1,10 @@
 import events from 'events';
 
-class ClientStub extends events.EventEmitter {}
+class ClientStub extends events.EventEmitter {
+  constructor(...args) {
+    super();
+    this.nick = args[1];
+  }
+}
 
 export default ClientStub;


### PR DESCRIPTION
As the irc library can change the nick of the bot when connecting (e.g. because the nick is currently taken, by some other user), `this.nickname` may not correspond to the current nickname and so when receiving a join event upon joining a channel (prior to the names event), the current guard against this can pass despite it being an event for the bot.

This modifies it to check against ircClient.nick where relevant, and also modifies the test stubs to allow adding the nickname to the config and exposing this functionality in tests.

To see the failure before this patch, enable `ircStatusNotices` and run two copies of the bot; the second should crash upon joining a channel, as it will have a modified nickname (e.g. 'testbot1').

The use of `...args` in the constructor is because it seems writing `constructor(_, nickname, _)` clashes due to same-named parameters, and `constructor(_server, nickname, _ircOptions)` seems to complain about unused variables (though the `_`s are intended to show that this has been acknowledged).