### PR TITLE
Skip sending falsy command preludes

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -51,7 +51,11 @@ class Bot {
     this.formatURLAttachment = this.format.urlAttachment || '<{$displayUsername}> {$attachmentURL}';
     // "{$keyName}" => "variableValue"
     // side: "Discord" or "IRC"
-    this.formatCommandPrelude = this.format.commandPrelude || 'Command sent from {$side} by {$nickname}:';
+    if ('commandPrelude' in this.format) {
+      this.formatCommandPrelude = this.format.commandPrelude;
+    } else {
+      this.formatCommandPrelude = 'Command sent from {$side} by {$nickname}:';
+    }
 
     // "{$keyName}" => "variableValue"
     // withMentions: text with appropriate mentions reformatted
@@ -282,9 +286,12 @@ class Bot {
 
       if (this.isCommandMessage(text)) {
         patternMap.side = 'Discord';
-        const prelude = Bot.substitutePattern(this.formatCommandPrelude, patternMap);
         logger.debug('Sending command message to IRC', ircChannel, text);
-        this.ircClient.say(ircChannel, prelude);
+        // if (prelude) this.ircClient.say(ircChannel, prelude);
+        if (this.formatCommandPrelude) {
+          const prelude = Bot.substitutePattern(this.formatCommandPrelude, patternMap);
+          this.ircClient.say(ircChannel, prelude);
+        }
         this.ircClient.say(ircChannel, text);
       } else {
         if (text !== '') {
@@ -345,9 +352,11 @@ class Bot {
 
     if (this.isCommandMessage(text)) {
       patternMap.side = 'IRC';
-      const prelude = Bot.substitutePattern(this.formatCommandPrelude, patternMap);
       logger.debug('Sending command message to Discord', `#${discordChannel.name}`, text);
-      discordChannel.sendMessage(prelude);
+      if (this.formatCommandPrelude) {
+        const prelude = Bot.substitutePattern(this.formatCommandPrelude, patternMap);
+        discordChannel.sendMessage(prelude);
+      }
       discordChannel.sendMessage(text);
       return;
     }

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -811,4 +811,35 @@ describe('Bot', function () {
     const expected = `<otherauthor> #discord => #irc, attachment: ${attachmentUrl}`;
     ClientStub.prototype.say.should.have.been.calledWith('#irc', expected);
   });
+
+  it('should not bother with command prelude if falsy', function () {
+    const format = { commandPrelude: null };
+    this.bot = new Bot({ ...configMsgFormatDefault, format });
+    this.bot.connect();
+
+    const text = '!testcmd';
+    const guild = createGuildStub();
+    const message = {
+      content: text,
+      mentions: { users: [] },
+      channel: {
+        name: 'discord'
+      },
+      author: {
+        username: 'testauthor',
+        id: 'not bot id'
+      },
+      guild
+    };
+
+    this.bot.sendToIRC(message);
+    ClientStub.prototype.say.should.have.been.calledOnce;
+    ClientStub.prototype.say.getCall(0).args.should.deep.equal(['#irc', text]);
+
+    const username = 'test';
+    const msg = '!testcmd';
+    this.bot.sendToDiscord(username, '#irc', msg);
+    this.sendMessageStub.should.have.been.calledOnce;
+    this.sendMessageStub.getCall(0).args.should.deep.equal([msg]);
+  });
 });


### PR DESCRIPTION
Fixes #239 by allowing falsy command preludes to override default, and then manually skipping them in the sendToIrc and sendToDiscord methods.

(The old `||` method for defaulting meant falsy preludes were overridden. It functions properly with just that area fixed, but the other modifications are to prevent sending empty messages, which causes `discord.js` to complain and is probably a bad idea to accidentally do anyway.)

This seems possibly abusable by users to hide who's sending commands from the IRC users' perspective, but it'd have to be done intentionally by the person running the bot, so I think it's acceptable.