### PR TITLE
Update link to IRC library docs (irc-upd instead of node-irc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ First you need to create a Discord bot user, which you can do by following the i
 ]
 ```
 
-The `ircOptions` object is passed directly to node-irc ([available options](http://node-irc.readthedocs.org/en/latest/API.html#irc.Client)).
+The `ircOptions` object is passed directly to irc-upd ([available options](https://node-irc-upd.readthedocs.io/en/latest/API.html#irc.Client)).
 
 To retrieve a discord channel ID, write `\#channel` on the relevant server – it should produce something of the form `<#1234567890>`, which you can then use in the `channelMapping` config.
 


### PR DESCRIPTION
As the upstream library has been changed to `irc-upd` instead of `node-irc`, change the README to point to its updated documentation (which now documents the `password` property usable in the `ircOptions` object, which was possible before but not described in documentation).

Here is the updated link, now in the README: https://node-irc-upd.readthedocs.io/en/latest/API.html#irc.Client