### PR TITLE
Improve IRC → Discord mentions for non-word characters and partial word matches

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -367,6 +367,22 @@ class Bot {
     return null;
   }
 
+  // compare two strings case-insensitively
+  // for discord mention matching
+  static caseComp(str1, str2) {
+    if (str1 === str2) return true;
+    if (typeof str1 !== 'string' || typeof str2 !== 'string') return false;
+    return str1.toUpperCase() === str2.toUpperCase();
+  }
+
+  // check if the first string starts with the second case-insensitively
+  // for discord mention matching
+  static caseStartsWith(str1, str2) {
+    if (str1 === str2) return true;
+    if (typeof str1 !== 'string' || typeof str2 !== 'string') return false;
+    return str1.toUpperCase().startsWith(str2.toUpperCase());
+  }
+
   sendToDiscord(author, channel, text) {
     const discordChannel = this.findDiscordChannel(channel);
     if (!discordChannel) return;
@@ -400,29 +416,72 @@ class Bot {
     }
 
     const { guild } = discordChannel;
-    const withMentions = withFormat.replace(/@[^\s]+\b/g, (match) => {
-      const search = match.substring(1);
-      const nickUser = guild.members.find('nickname', search);
-      if (nickUser) {
-        return nickUser;
-      }
+    const withMentions = withFormat.replace(/@([^\s#]+)#(\d+)/g, (match, username, discriminator) => {
+      // @username#1234 => mention
+      // skips usernames including spaces for ease (they cannot include hashes)
+      // checks case insensitively as Discord does
+      const user = guild.members.find(x =>
+        Bot.caseComp(x.user.username, username.toUpperCase())
+        && x.user.discriminator === discriminator);
+      if (user) return user;
 
-      const user = this.discord.users.find('username', search);
-      if (user) {
-        return user;
-      }
+      return match;
+    }).replace(/@([^\s]+)/g, (match, reference) => {
+      // this preliminary stuff is ultimately unnecessary
+      // but might save time over later more complicated calculations
+      // @nickname => mention, case insensitively
+      const nickUser = guild.members.find(x => Bot.caseComp(x.nickname, reference));
+      if (nickUser) return nickUser;
 
-      const role = guild.roles.find('name', search);
-      if (role && role.mentionable) {
-        return role;
-      }
+      // @username => mention, case insensitively
+      const user = guild.members.find(x => Bot.caseComp(x.user.username, reference));
+      if (user) return user;
+
+      // @role => mention, case insensitively
+      const role = guild.roles.find(x => x.mentionable && Bot.caseComp(x.name, reference));
+      if (role) return role;
+
+      // No match found checking the whole word. Check for partial matches now instead.
+      // @nameextra => [mention]extra, case insensitively, as Discord does
+      // uses the longest match, and if there are two, whichever is a match by case
+      let matchLength = 0;
+      let bestMatch = null;
+      let caseMatched = false;
+
+      // check if a partial match is found in reference and if so update the match values
+      const checkMatch = function (matchString, matchValue) {
+        // if the matchString is longer than the current best and is a match
+        // or if it's the same length but it matches by case unlike the current match
+        // set the best match to this matchString and matchValue
+        if ((matchString.length > matchLength && Bot.caseStartsWith(reference, matchString))
+          || (matchString.length === matchLength && !caseMatched
+              && reference.startsWith(matchString))) {
+          matchLength = matchString.length;
+          bestMatch = matchValue;
+          caseMatched = reference.startsWith(matchString);
+        }
+      };
+
+      // check users by username and nickname
+      guild.members.forEach((member) => {
+        checkMatch(member.user.username, member);
+        if (bestMatch === member || member.nickname === null) return;
+        checkMatch(member.nickname, member);
+      });
+      // check mentionable roles by visible name
+      guild.roles.forEach((member) => {
+        if (!member.mentionable) return;
+        checkMatch(member.name, member);
+      });
+
+      // if a partial match was found, return the match and the unmatched trailing characters
+      if (bestMatch) return bestMatch.toString() + reference.substring(matchLength);
 
       return match;
     }).replace(/:(\w+):/g, (match, ident) => {
+      // :emoji: => mention, case sensitively
       const emoji = guild.emojis.find(x => x.name === ident && x.requiresColons);
-      if (emoji) {
-        return `<:${emoji.identifier}>`; // identifier = name + ":" + id
-      }
+      if (emoji) return emoji;
 
       return match;
     });

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -370,16 +370,12 @@ class Bot {
   // compare two strings case-insensitively
   // for discord mention matching
   static caseComp(str1, str2) {
-    if (str1 === str2) return true;
-    if (typeof str1 !== 'string' || typeof str2 !== 'string') return false;
     return str1.toUpperCase() === str2.toUpperCase();
   }
 
   // check if the first string starts with the second case-insensitively
   // for discord mention matching
   static caseStartsWith(str1, str2) {
-    if (str1 === str2) return true;
-    if (typeof str1 !== 'string' || typeof str2 !== 'string') return false;
     return str1.toUpperCase().startsWith(str2.toUpperCase());
   }
 
@@ -430,7 +426,8 @@ class Bot {
       // this preliminary stuff is ultimately unnecessary
       // but might save time over later more complicated calculations
       // @nickname => mention, case insensitively
-      const nickUser = guild.members.find(x => Bot.caseComp(x.nickname, reference));
+      const nickUser = guild.members.find(x =>
+        x.nickname !== null && Bot.caseComp(x.nickname, reference));
       if (nickUser) return nickUser;
 
       // @username => mention, case insensitively

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -577,7 +577,12 @@ describe('Bot', function () {
 
   it('should convert username-discriminator mentions from IRC properly', function () {
     const user1 = this.addUser({ username: 'user', id: '123', discriminator: '9876' });
-    const user2 = this.addUser({ username: 'user', id: '124', discriminator: '5555', nickname: 'secondUser' });
+    const user2 = this.addUser({
+      username: 'user',
+      id: '124',
+      discriminator: '5555',
+      nickname: 'secondUser'
+    });
 
     const username = 'ircuser';
     const text = 'hello @user#9876 and @user#5555 and @fakeuser#1234';


### PR DESCRIPTION
Previously, attempting to mention someone with non-`\w` characters in their name would fail. So if you're on a server with a lot of non-latin names, or one where users have mysterious symbols in their names to indicate something (an example could be 'Throne✶', with the '✶' representing that one is an admin) then IRC users would not properly be able to ping them, as it wasn't recognized as being a wordy character. (Fortunately, if the user in question has 'Throne3d' as their Discord username, that worked as a fallback, but it was non-obvious. Typing the symbol would also be hard but plausibly could be copied and pasted.)

This builds on #272 (which standardizes the testing suite in ways that make this easier to test), adds case-insensitive username and nickname matching, matches all strings of characters that don't involve spaces or hash symbols instead of just `\w` ones, adds matching for mentions of the format `@username#discriminator`, and will match partially – e.g., if there's a user "Throne" in the channel, `@Thronetest`, `@Throne's` and `@Throne-won't-see-this` will all have the starting `@Throne` matched and turned into a mention, as Discord does with usernames.

The partial matching prefers longer matches first and foremost, case insensitively, and then prefers matches which have exact case. I couldn't find an easy method to compare case-insensitively across locales (it seems to require you list the locales you want to compare across), and I'm not sure what Discord does internally, so I uppercased them then compared (and have this in a separate function to make it easier to change later, if necessary).

There is, I think, duplicated logic, in that it checks for perfect non-partial matches first, but if that special casing were removed it should produce the same result (except with a bias towards exact case match, instead of what order the Collection uses behind the scenes), but I wasn't sure if there might be some sort of performance problem with large Discord servers so I thought it best to leave that there, at least for now.