### PR TITLE
Fix test globbing on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build": "babel lib --out-dir dist",
     "prepublish": "npm run build",
     "lint": "eslint . --ignore-path .gitignore",
-    "coverage": "nyc --require babel-core/register _mocha -- $(find test -name '*.test.js')",
+    "coverage": "nyc --require babel-core/register _mocha -- test/*.test.js",
     "report": "nyc report --reporter=text-lcov | coveralls",
     "test": "npm run lint && npm run coverage"
   },


### PR DESCRIPTION
Windows doesn't support the inline evaluation `$(find..)` and also doesn't support the find command. `nyc` can handle globbing itself, as can it appears `_mocha` (i.e. this command works both without and with the `--` given just before the globbing), so it doesn't seem the find command is necessary.

This allows `npm test` to function on Windows using PowerShell (and presumably also command prompt). For some reason the coverage report is missing data, but it misses data without this change also.

Assuming this doesn't break Travis it should be good to go.

(Windows actually does execute the tests on master, because `nyc` or `mocha` receives no valid parameters and so I think defaults to the `test` directory, but it exits with an error code. This fixes that, but does not fix the lack of coverage data on Windows.)