### PR TITLE
bot.js: enable autoRenick by default

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -86,6 +86,8 @@ class Bot {
       floodProtection: true,
       floodProtectionDelay: 500,
       retryCount: 10,
+      autoRenick: true,
+      // options specified in the configuration file override the above defaults
       ...this.ircOptions
     };
 


### PR DESCRIPTION
When the client reconnects to IRC after a timeout, the bot nickname
is often still in use (the client receives an `err_nicknameinuse`
message), and the bot is given an alternate nickname by the server.
In this case, it is almost always desirable to try to change the
nickname back to the configured nickname, so we enable `autoRenick`
by default.

NOTE: `autoRenick` can be disabled by specifying `autoRenick: false`
in `ircOptions` in the discord-irc configuration file, or the
behavior can be modified with the `renickCount` and `renickDelay`
options. See the node-irc documentation for more details.