### PR TITLE
Set default encoding to UTF-8

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ To retrieve a discord channel ID, write `\#channel` on the relevant server – i
 
 ### Encodings
 
-If you encounter trouble with some characters being corrupted from some clients (particularly umlauted characters, such as `ä` or `ö`), try installing the optional dependencies `iconv` and `node-icu-charset-detector`, then adding `"encoding": "utf-8"` to your `ircOptions` object.
+If you encounter trouble with some characters being corrupted from some clients (particularly umlauted characters, such as `ä` or `ö`), try installing the optional dependencies `iconv` and `node-icu-charset-detector`.
+The bot will produce a warning when started if the IRC library is unable to convert between encodings.
 
 Further information can be found in [the installation section of irc-upd](https://github.com/Throne3d/node-irc#character-set-detection).
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ import config from './config.json';
 discordIRC(config);
 ```
 
+When installing the library, you may encounter an error relating to the installation of `iconv` or `node-icu-charset-detector`.
+These are optional dependencies which allow you to set the target encoding of messages sent to Discord, as detailed below in the README.
+Without these dependencies and the relevant setting, messages that aren't sent in UTF-8 may be corrupted when copied to Discord.
+
 ## Configuration
 First you need to create a Discord bot user, which you can do by following the instructions [here](https://github.com/reactiflux/discord-irc/wiki/Creating-a-discord-bot-&-getting-a-token).
 
@@ -93,6 +97,12 @@ First you need to create a Discord bot user, which you can do by following the i
 The `ircOptions` object is passed directly to irc-upd ([available options](https://node-irc-upd.readthedocs.io/en/latest/API.html#irc.Client)).
 
 To retrieve a discord channel ID, write `\#channel` on the relevant server – it should produce something of the form `<#1234567890>`, which you can then use in the `channelMapping` config.
+
+### Encodings
+
+If you encounter trouble with some characters being corrupted from some clients (particularly umlauted characters, such as `ä` or `ö`), try installing the optional dependencies `iconv` and `node-icu-charset-detector`, then adding `"encoding": "utf-8"` to your `ircOptions` object.
+
+Further information can be found in [the installation section of irc-upd](https://github.com/Throne3d/node-irc#character-set-detection).
 
 ## Tests
 Run the tests with:

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -92,11 +92,12 @@ class Bot {
     };
 
     // default encoding to UTF-8 so messages to Discord aren't corrupted
-    if (!('encoding' in ircOptions)) {
+    if (!Object.prototype.hasOwnProperty.call(ircOptions, 'encoding')) {
       if (irc.canConvertEncoding()) {
         ircOptions.encoding = 'utf-8';
       } else {
-        logger.warn('Cannot convert message encoding; you may encounter corrupted characters with non-English text.');
+        logger.warn('Cannot convert message encoding; you may encounter corrupted characters with non-English text.\n' +
+          'For information on how to fix this, please see: https://github.com/Throne3d/node-irc#character-set-detection');
       }
     }
 

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -91,6 +91,15 @@ class Bot {
       ...this.ircOptions
     };
 
+    // default encoding to UTF-8 so messages to Discord aren't corrupted
+    if (!('encoding' in ircOptions)) {
+      if (irc.canConvertEncoding()) {
+        ircOptions.encoding = 'utf-8';
+      } else {
+        logger.warn('Cannot convert message encoding; you may encounter corrupted characters with non-English text.');
+      }
+    }
+
     this.ircClient = new irc.Client(this.server, this.nickname, ircOptions);
     this.attachListeners();
   }


### PR DESCRIPTION
Per #237, it would be good to default to using the UTF-8 encoding when the upstream IRC library is able to support this. There should also be some sort of mention in the README about how to ensure the bot can convert encodings.

This doesn't have tests for these lines. I'm not sure how to stub `irc.canConvertEncoding()` except by including a new development dependency of `proxyquire`, which is designed for specifically the purpose of stubbing requires on other files. Suggestions, comments?