### PR TITLE
Make it work with group DM

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -219,9 +219,11 @@ class Bot {
   }
 
   static getDiscordNicknameOnServer(user, guild) {
-    const userDetails = guild.members.get(user.id);
-    if (userDetails) {
-      return userDetails.nickname || user.username;
+    if (guild) {
+      const userDetails = guild.members.get(user.id);
+      if (userDetails) {
+        return userDetails.nickname || user.username;
+      }
     }
     return user.username;
   }


### PR DESCRIPTION
Crashes if you try to use it with private messages, because guild.members does not exist.
This change fixes that.