### PR TITLE
Support displayUsername when sending message to discord

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -357,6 +357,7 @@ class Bot {
     const patternMap = {
       author,
       nickname: author,
+      displayUsername: author,
       text: withFormat,
       discordChannel: `#${discordChannel.name}`,
       ircChannel: channel


### PR DESCRIPTION
This allows displayUsername to be used in the command prelude. Before this change, if displayUsername was used in command prelude, it would not display correctly when a command was sent from IRC to Discord.