### PR TITLE
Use a prepare script for transpiling instead of prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "start": "node dist/index.js",
     "build": "babel lib --out-dir dist",
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "lint": "eslint . --ignore-path .gitignore",
     "coverage": "nyc --require babel-core/register _mocha -- test/*.test.js",
     "report": "nyc report --reporter=text-lcov | coveralls",


### PR DESCRIPTION
From [Travis logs](https://travis-ci.org/reactiflux/discord-irc/jobs/283778593#L460) (in the `npm install` script):
As of npm@5, `prepublish` scripts will run only for `npm publish`.
(In npm@4 and previous versions, it also runs for `npm install`.)
See the deprecation note in `npm help scripts` for more information.

This was also causing discord-irc to fail to transpile when installed using npm from source. (`npm install -g reactiflux/discord-irc` fails, but `npm install -g Throne3d/discord-irc`, using this patch, succeeds.)

This modifies the script to run on the `prepare` hook, so it should transpile when installed directly from source too.