### PR TITLE
Add config option discordStatus

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ First you need to create a Discord bot user, which you can do by following the i
     "ignoreUsers": {
       "irc": ["irc_nick1", "irc_nick2"], // Ignore specified IRC nicks and do not send their messages to Discord.
       "discord": ["discord_nick1", "discord_nick2"] // Ignore specified Discord nicks and do not send their messages to IRC.
-    }
+    },
+    "discordStatus": "IRC"
   }
 ]
 ```

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -36,6 +36,7 @@ class Bot {
     this.channels = _.values(options.channelMapping);
     this.ircStatusNotices = options.ircStatusNotices;
     this.announceSelfJoin = options.announceSelfJoin;
+    this.discordStatus = options.discordStatus;
 
     // Nicks to ignore
     this.ignoreUsers = options.ignoreUsers || {};
@@ -113,6 +114,12 @@ class Bot {
   attachListeners() {
     this.discord.on('ready', () => {
       logger.info('Connected to Discord');
+      if (this.discordStatus) {
+        this.discord.user.setPresence({
+          status: 'online',
+          game: { name: this.discordStatus }
+        });
+      }
     });
 
     this.ircClient.on('registered', (message) => {


### PR DESCRIPTION
See issue #246. I needed this on my server, and this seems to work.

It might be more powerful to expose the whole [PrecenseData](https://discord.js.org/#/docs/main/stable/typedef/PresenceData) object as a setting, but I think simple string is nicer to use and covers most use cases.