### PR TITLE
Allow sending IRC topic changes to Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ First you need to create a Discord bot user, which you can do by following the i
       "#discord": "#irc channel-password", // Add channel keys after the channel name
       "1234567890": "#channel" // Use a discord channel ID instead of its name (so you can rename it or to disambiguate)
     },
+    "channelTopicsToDiscord": [ // Sends topic changes from IRC to Discord
+      "#irc
+    ],
     "ircOptions": { // Optional node-irc options
       "floodProtection": false, // On by default
       "floodProtectionDelay": 1000 // 500 by default

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -243,7 +243,9 @@ class Bot {
       this.ircClient.on('topic', (channel, topic, nick, message) => {
         if (message.command !== 'rpl_topicwhotime') {
           logger.debug('Received topic change from IRC:', channel, topic);
-          if (this.channelTopicsToDiscord === true || this.channelTopicsToDiscord.includes(channel)) {
+          const channelIncluded = this.channelTopicsToDiscord === true ||
+            this.channelTopicsToDiscord.includes(channel);
+          if (channelIncluded) {
             this.sendExactToDiscord(channel, `*${nick}* has changed the topic to "${topic}"`);
           }
         }

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -37,6 +37,7 @@ class Bot {
     this.ircStatusNotices = options.ircStatusNotices;
     this.announceSelfJoin = options.announceSelfJoin;
     this.webhookOptions = options.webhooks;
+    this.channelTopicsToDiscord = options.channelTopicsToDiscord;
 
     // Nicks to ignore
     this.ignoreUsers = options.ignoreUsers || {};
@@ -237,6 +238,17 @@ class Bot {
         logger.debug('Joining channel:', channel);
       }
     });
+
+    if (typeof this.channelTopicsToDiscord !== 'undefined') {
+      this.ircClient.on('topic', (channel, topic, nick, message) => {
+        if (message.command !== 'rpl_topicwhotime') {
+          logger.debug('Received topic change from IRC:', channel, topic);
+          if (this.channelTopicsToDiscord === true || this.channelTopicsToDiscord.includes(channel)) {
+            this.sendExactToDiscord(channel, `*${nick}* has changed the topic to "${topic}"`);
+          }
+        }
+      });
+    }
 
     if (logger.level === 'debug') {
       this.discord.on('debug', (message) => {


### PR DESCRIPTION
This change allows the bot to send IRC topics from all channels (setting `true`) or specific channels (setting `Array` of names) through to Discord as a plain message like this:

> **discord-irc** _IRCUser_ has changed the topic to "IRC topic"

I had a go at sending Discord topics the other way but it didn't work, I think because it was trying to identify the author of the Discord event and there isn't one.

Part of reactiflux/discord-irc#220