### PR TITLE
Fix parsing of animated emoji from Discord

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -275,7 +275,7 @@ class Bot {
         if (role) return `@${role.name}`;
         return '@deleted-role';
       })
-      .replace(/<(:\w+:)\d+>/g, (match, emoteName) => emoteName);
+      .replace(/<a?(:\w+:)\d+>/g, (match, emoteName) => emoteName);
   }
 
   isCommandMessage(message) {

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -423,6 +423,15 @@ describe('Bot', function () {
     this.bot.parseText(message).should.equal(':SCGWat:');
   });
 
+  it('should convert animated emoji from discord', function () {
+    const message = {
+      mentions: { users: [] },
+      content: '<a:in_love:432887860270465028>'
+    };
+
+    this.bot.parseText(message).should.equal(':in_love:');
+  });
+
   it('should convert user mentions from IRC', function () {
     const testUser = this.addUser({ username: 'testuser', id: '123' });
 


### PR DESCRIPTION
(Fixes #384.)

On the Discord side of things, the new animated emoji get `a` prefixed to their identifier string, so that instead of the normal emoji string:
`<:test:330064465703862273>`
you instead get:
`<a:test:330064465703862273>`

This commit fixes `parseText` to also process the animated form into `:test:` (as we currently do for non-animated emoji).