### PR TITLE
Ability to define just one color for nicks sent to IRC

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -33,6 +33,9 @@ class Bot {
     this.discordToken = options.discordToken;
     this.commandCharacters = options.commandCharacters || [];
     this.ircNickColor = options.ircNickColor !== false; // default to true
+    this.ircNickColorIndex = (options.ircNickColorIndex < NICK_COLORS.length) ?
+      options.ircNickColorIndex :
+      false;
     this.channels = _.values(options.channelMapping);
     this.ircStatusNotices = options.ircStatusNotices;
     this.announceSelfJoin = options.announceSelfJoin;
@@ -317,7 +320,10 @@ class Bot {
       let text = this.parseText(message);
       let displayUsername = nickname;
       if (this.ircNickColor) {
-        const colorIndex = (nickname.charCodeAt(0) + nickname.length) % NICK_COLORS.length;
+        // If colorIndex is set in conf use that value
+        const colorIndex = this.ircNickColorIndex ?
+          this.ircNickColorIndex :
+          (nickname.charCodeAt(0) + nickname.length) % NICK_COLORS.length;
         displayUsername = irc.colors.wrap(NICK_COLORS[colorIndex], nickname);
       }
 


### PR DESCRIPTION
This enables users to configure the color used for nicks sent to IRC
based on the index of NICK_COLORS. This is a middleground for those who do not
want their IRC client to look like a rainbow but sitll have some color for
readability.