### PR TITLE
Add format.webhookAvatarURL option (fixes #383)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,11 @@ First you need to create a Discord bot user, which you can do by following the i
       "commandPrelude": "Command sent by {$nickname}", // Message sent before a command
       "ircText": "<{$displayUsername}> {$text}", // When sending a message to IRC
       "urlAttachment": "<{$displayUsername}> {$attachmentURL}", // When sending a Discord attachment to IRC
-      "discord": "**<{$author}>** {$withMentions}" // When sending a message to Discord
+      "discord": "**<{$author}>** {$withMentions}", // When sending a message to Discord
       // Other patterns that can be used:
       // {$discordChannel} (e.g. #general)
       // {$ircChannel} (e.g. #irc)
+      "webhookAvatarURL": "https://robohash.org/{$nickname}" // Default avatar to use for webhook messages
     },
     "ircNickColor": false, // Gives usernames a color in IRC for better readability (on by default)
     // Makes the bot hide the username prefix for messages that start

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -55,6 +55,7 @@ class Bot {
     // attachmentURL: the URL of the attachment (only applicable in formatURLAttachment)
     this.formatIRCText = this.format.ircText || '<{$displayUsername}> {$text}';
     this.formatURLAttachment = this.format.urlAttachment || '<{$displayUsername}> {$attachmentURL}';
+
     // "{$keyName}" => "variableValue"
     // side: "Discord" or "IRC"
     if ('commandPrelude' in this.format) {
@@ -66,6 +67,10 @@ class Bot {
     // "{$keyName}" => "variableValue"
     // withMentions: text with appropriate mentions reformatted
     this.formatDiscord = this.format.discord || '**<{$author}>** {$withMentions}';
+
+    // "{$keyName} => "variableValue"
+    // nickname: nickame of IRC message sender
+    this.formatWebhookAvatarURL = this.format.webhookAvatarURL;
 
     // Keep track of { channel => [list, of, usernames] } for ircStatusNotices
     this.channelUsers = {};
@@ -408,9 +413,14 @@ class Bot {
       users = guildMembers.filter(findByNicknameOrUsername(false));
     }
 
-    // No matching user or more than one => no avatar
+    // No matching user or more than one => default avatar
     if (users && users.size === 1) {
       return users.first().user.avatarURL;
+    }
+
+    // If there isn't a URL format, don't send an avatar at all
+    if (this.formatWebhookAvatarURL) {
+      return Bot.substitutePattern(this.formatWebhookAvatarURL, { nickname: nick });
     }
     return null;
   }

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -967,12 +967,27 @@ describe('Bot', function () {
     chai.should().equal(this.bot.getDiscordAvatar('common', '#irc'), null);
   });
 
+  it('should use the default avatar URL format if one is specified and there is no matching user', function () {
+    const newConfig = { ...config, webhooks: { '#discord': 'https://discordapp.com/api/webhooks/id/token' }, format: { webhookAvatarURL: 'avatarFrom/{$nickname}' } };
+    const bot = new Bot(newConfig);
+    this.bot = bot;
+    bot.connect();
+    const userObj1 = { id: 128, username: 'common', avatar: 'avatarURL' };
+    const userObj2 = { id: 129, username: 'Nick', avatar: 'avatarURL' };
+    const memberObj1 = { nickname: 'Different' };
+    const memberObj2 = { nickname: 'common' };
+    this.addUser(userObj1, memberObj1);
+    this.addUser(userObj2, memberObj2);
+    chai.should().equal(this.bot.getDiscordAvatar('common', '#irc'), 'avatarFrom/common');
+    chai.should().equal(this.bot.getDiscordAvatar('nonexistant', '#irc'), 'avatarFrom/nonexistant');
+  });
+
   it('should not return an avatar when no users match and should handle lack of nickname, when looking for an avatar', function () {
     const newConfig = { ...config, webhooks: { '#discord': 'https://discordapp.com/api/webhooks/id/token' } };
     const bot = new Bot(newConfig);
     bot.connect();
-    const userObj1 = { id: 128, username: 'common', avatar: 'avatarURL' };
-    const userObj2 = { id: 129, username: 'Nick', avatar: 'avatarURL' };
+    const userObj1 = { id: 130, username: 'common', avatar: 'avatarURL' };
+    const userObj2 = { id: 131, username: 'Nick', avatar: 'avatarURL' };
     const memberObj1 = {};
     const memberObj2 = { nickname: 'common' };
     this.addUser(userObj1, memberObj1);


### PR DESCRIPTION
As discussed in #383, adds a `format.webhookAvatarURL` option to the config which allows users to point to a custom URL or web service to generate avatars for unrecognized IRC nicks in Discord. The option is left undefined by default, which is handled by not sending an avatar at all (which is the current behavior). I'm open to changing this default if that would be better.

I attempted to add a test for this, but it appears there is a discrepancy in all the tests between `this.bot` and individually created `bot` variables, which prevents `addUser` from working on bot instances created for individual tests. I worked around this by simply setting `this.bot = bot` in the new test, but I have a feeling this isn't a good practice (I'm new to writing tests in general). Further guidance on that would be appreciated. I would be willing to attempt another PR to correct this behavior across all tests if needed.