### PR TITLE
use non-deprecated form of `Array.find`

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -369,7 +369,7 @@ class Bot {
       // #channel -> channel before retrieving and select only text channels:
       const discordChannel = discordChannelName.startsWith('#') ? this.discord.channels
         .filter(c => c.type === 'text')
-        .find('name', discordChannelName.slice(1)) : this.discord.channels.get(discordChannelName);
+        .find(c => c.name === discordChannelName.slice(1)) : this.discord.channels.get(discordChannelName);
 
       if (!discordChannel) {
         logger.info(


### PR DESCRIPTION
The older form emitted a deprecation warning in nodejs, cluttering up the log.