### PR TITLE
use util.inspect for logger instead of json.stringify

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,11 +1,15 @@
 import winston, { format } from 'winston';
+import { inspect } from 'util';
 
 function formatter(info) {
-  const stringifiedRest = JSON.stringify(Object.assign({}, info, {
-    level: undefined,
-    message: undefined,
-    splat: undefined
-  }));
+  const stringifiedRest = inspect(
+    Object.assign({}, info, {
+      level: undefined,
+      message: undefined,
+      splat: undefined
+    }),
+    { depth: null }
+  );
 
   const padding = (info.padding && info.padding[info.level]) || '';
   if (stringifiedRest !== '{}') {


### PR DESCRIPTION
JSON.stringify can't represent every value from our application
passed to logger, but util.inspect can.

this fixes #446