### PR TITLE
Update bot.js

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -543,7 +543,7 @@ class Bot {
       logger.debug('Sending message to Discord via webhook', withMentions, channel, '->', `#${discordChannel.name}`);
       const avatarURL = this.getDiscordAvatar(author, channel);
       webhook.client.sendMessage(withMentions, {
-        username: author,
+        username: _.padEnd(author.substring(0, 32), 2, '_'),
         text,
         avatarURL
       }).catch(logger.error);


### PR DESCRIPTION
Username must be between 2 and 32 in length, even in the webhook. Unless the message won't be send. Reported by @guswns0528

##### Reference
- https://discordapp.com/developers/docs/resources/user#usernames-and-nicknames