### PR TITLE
add ignoredWords feature (doesn't forward messages containing an igno…

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -31,7 +31,8 @@ class Bot {
     this.nickname = options.nickname;
     this.ircOptions = options.ircOptions;
     this.discordToken = options.discordToken;
-    this.ignoredWords = options.ignoredWords || []; // default don't ignore any words
+    this.filterWords = options.filterWords || []; // default don't filter any words
+    this.filterPrefixes = options.filterPrefixes || []; // default don't filter any prefixes
     this.commandCharacters = options.commandCharacters || [];
     this.ircNickColor = options.ircNickColor !== false; // default to true
     this.channels = _.values(options.channelMapping);
@@ -279,8 +280,12 @@ class Bot {
       .replace(/<a?(:\w+:)\d+>/g, (match, emoteName) => emoteName);
   }
 
-  isIgnoredMessage(message) {
-    return this.ignoredWords.some(word => message.toLowerCase().includes(word.toLowerCase())); // word found in list of ignoredWords
+  isFilterWordMessage(message) {
+    return this.filterWords.some(word => message.toLowerCase().includes(word.toLowerCase())); // word found in list of filterWords
+  }
+
+  isFilterPrefixMessage(message) {
+    return this.filterPrefixes.some(prefix => message.toLowerCase().startsWith(prefix.toLowerCase())); // prefix found in list of filterPrefixes
   }
 
   isCommandMessage(message) {
@@ -335,8 +340,12 @@ class Bot {
         ircChannel
       };
 
-      if (this.isIgnoredMessage(text)) { // if discord message contains a word that's on the ignore list
-        //logger.debug('Message contained word which was in ignoredWords config. Not sending to IRC', ircChannel, text);
+      if (this.isFilterWordMessage(text)) { // if discord message contains a word that's on the filter list
+        //logger.debug('Message contained word which was in filterWords config. Not sending to IRC', ircChannel, text);
+        return; // don't forward to IRC
+      };
+      if (this.isFilterPrefixMessage(text)) { // if discord message starts with a prefix that's on the filter list
+        //logger.debug('Message started with a prefix which was in filterPrefixes config. Not sending to IRC', ircChannel, text);
         return; // don't forward to IRC
       };
       if (this.isCommandMessage(text)) {

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -31,6 +31,7 @@ class Bot {
     this.nickname = options.nickname;
     this.ircOptions = options.ircOptions;
     this.discordToken = options.discordToken;
+    this.ignoredWords = options.ignoredWords || []; // default don't ignore any words
     this.commandCharacters = options.commandCharacters || [];
     this.ircNickColor = options.ircNickColor !== false; // default to true
     this.channels = _.values(options.channelMapping);
@@ -278,6 +279,10 @@ class Bot {
       .replace(/<a?(:\w+:)\d+>/g, (match, emoteName) => emoteName);
   }
 
+  isIgnoredMessage(message) {
+    return this.ignoredWords.some(word => message.toLowerCase().includes(word.toLowerCase())); // word found in list of ignoredWords
+  }
+
   isCommandMessage(message) {
     return this.commandCharacters.some(prefix => message.startsWith(prefix));
   }
@@ -330,6 +335,10 @@ class Bot {
         ircChannel
       };
 
+      if (this.isIgnoredMessage(text)) { // if discord message contains a word that's on the ignore list
+        //logger.debug('Message contained word which was in ignoredWords config. Not sending to IRC', ircChannel, text);
+        return; // don't forward to IRC
+      };
       if (this.isCommandMessage(text)) {
         patternMap.side = 'Discord';
         logger.debug('Sending command message to IRC', ircChannel, text);


### PR DESCRIPTION
…redWord)

example configuration option (top level JSON key):
"bannedWords": ["pleasebanme", "testsomewords", "thingsYouWouldntPutInACommitMessage"]

tested working, built in docker.

feel free to change code style, naming, whatever you like.