### PR TITLE
Add webhookDisableEveryone option

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -41,6 +41,7 @@ class Bot {
     this.ircStatusNotices = options.ircStatusNotices;
     this.announceSelfJoin = options.announceSelfJoin;
     this.webhookOptions = options.webhooks;
+    this.webhookDisableEveryone = options.webhookDisableEveryone;
 
     // Nicks to ignore
     this.ignoreUsers = options.ignoreUsers || {};
@@ -560,7 +561,8 @@ class Bot {
       webhook.client.sendMessage(withMentions, {
         username,
         text,
-        avatarURL
+        avatarURL,
+        disableEveryone: this.webhookDisableEveryone,
       }).catch(logger.error);
       return;
     }


### PR DESCRIPTION
On Discord, webhooks automatically have mass ping permissions that can't be removed. This patch adds a config option to tell discord.js to insert an invisible character in mass pings to prevent this from happening.