### PR TITLE
Match IRC-style mentions at beginning of message

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -476,7 +476,9 @@ class Bot {
       if (user) return user;
 
       return match;
-    }).replace(/@([^\s]+)/g, (match, reference) => {
+    }).replace(/^([^@\s:,]+)[:,]|@([^\s]+)/g, (match, startRef, atRef) => {
+      const reference = startRef || atRef;
+
       // this preliminary stuff is ultimately unnecessary
       // but might save time over later more complicated calculations
       // @nickname => mention, case insensitively

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -432,7 +432,7 @@ describe('Bot', function () {
     this.bot.parseText(message).should.equal(':in_love:');
   });
 
-  it('should convert user mentions from IRC', function () {
+  it('should convert user at-mentions from IRC', function () {
     const testUser = this.addUser({ username: 'testuser', id: '123' });
 
     const username = 'ircuser';
@@ -443,10 +443,52 @@ describe('Bot', function () {
     this.sendStub.should.have.been.calledWith(expected);
   });
 
-  it('should not convert user mentions from IRC if such user does not exist', function () {
+  it('should convert user colon-initial mentions from IRC', function () {
+    const testUser = this.addUser({ username: 'testuser', id: '123' });
+
+    const username = 'ircuser';
+    const text = 'testuser: hello!';
+    const expected = `**<${username}>** <@${testUser.id}> hello!`;
+
+    this.bot.sendToDiscord(username, '#irc', text);
+    this.sendStub.should.have.been.calledWith(expected);
+  });
+
+  it('should convert user comma-initial mentions from IRC', function () {
+    const testUser = this.addUser({ username: 'testuser', id: '123' });
+
+    const username = 'ircuser';
+    const text = 'testuser, hello!';
+    const expected = `**<${username}>** <@${testUser.id}> hello!`;
+
+    this.bot.sendToDiscord(username, '#irc', text);
+    this.sendStub.should.have.been.calledWith(expected);
+  });
+
+  it('should not convert user initial mentions from IRC mid-message', function () {
+    this.addUser({ username: 'testuser', id: '123' });
+
+    const username = 'ircuser';
+    const text = 'Hi there testuser, how goes?';
+    const expected = `**<${username}>** Hi there testuser, how goes?`;
+
+    this.bot.sendToDiscord(username, '#irc', text);
+    this.sendStub.should.have.been.calledWith(expected);
+  });
+
+  it('should not convert user at-mentions from IRC if such user does not exist', function () {
     const username = 'ircuser';
     const text = 'See you there @5pm';
     const expected = `**<${username}>** See you there @5pm`;
+
+    this.bot.sendToDiscord(username, '#irc', text);
+    this.sendStub.should.have.been.calledWith(expected);
+  });
+
+  it('should not convert user initial mentions from IRC if such user does not exist', function () {
+    const username = 'ircuser';
+    const text = 'Agreed, see you then.';
+    const expected = `**<${username}>** Agreed, see you then.`;
 
     this.bot.sendToDiscord(username, '#irc', text);
     this.sendStub.should.have.been.calledWith(expected);


### PR DESCRIPTION
On my IRC channel I've noticed people expect to be able to address Discord users like they usually do on IRC, in one of these two forms:
```
<ircuser1> discorduser: yes, I agree
<ircuser2> discorduser, I also agree with that
```

This PR makes it possible by extending the mention regex to transform a `discorduser:` or `discorduser,` at the beginning of a message into `@discorduser`.