### PR TITLE
fix: prevent using @everyone from an IRC channel

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -560,7 +560,8 @@ class Bot {
       webhook.client.sendMessage(withMentions, {
         username,
         text,
-        avatarURL
+        avatarURL,
+        disableEveryone: true
       }).catch(logger.error);
       return;
     }

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -986,6 +986,7 @@ describe('Bot', function () {
       username: 'n_',
       text,
       avatarURL: null,
+      disableEveryone: true,
     });
   });
 
@@ -999,6 +1000,7 @@ describe('Bot', function () {
       username: '12345678901234567890123456789012',
       text,
       avatarURL: null,
+      disableEveryone: true,
     });
   });
 


### PR DESCRIPTION
This prevents IRC users spamming @everyone in massive Discord chats :) 

Fixed #494