### PR TITLE
Run all test/*.test.js files

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build": "babel lib --out-dir dist",
     "prepare": "npm run build",
     "lint": "eslint . --ignore-path .gitignore",
-    "coverage": "nyc --require babel-core/register _mocha -- test/*.test.js",
+    "coverage": "nyc --require babel-core/register _mocha -- 'test/*.test.js'",
     "report": "nyc report --reporter=text-lcov | coveralls",
     "test": "npm run lint && npm run coverage"
   },


### PR DESCRIPTION
Somehow, upgrading either mocha or nyc (?) appears to make the current test command skip test/bot-events.test.js. I do not know why, but quoting it (so mocha globs it instead) seems to fix this.

(This happened between 2.7.0 and 2.7.1.)