### PR TITLE
Add ircPreventMention

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ First you need to create a Discord bot user, which you can do by following the i
       "webhookAvatarURL": "https://robohash.org/{$nickname}" // Default avatar to use for webhook messages
     },
     "ircNickColor": false, // Gives usernames a color in IRC for better readability (on by default)
-    "ircPreventMention": false, // Prevents users of both IRC and Discord from being mentioned in IRC when they speak in Discord (on by default)
+    "ircPreventMention": true, // Prevents users of both IRC and Discord from being mentioned in IRC when they speak in Discord (off by default)
     // Makes the bot hide the username prefix for messages that start
     // with one of these characters (commands):
     "commandCharacters": ["!", "."],

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ First you need to create a Discord bot user, which you can do by following the i
       "webhookAvatarURL": "https://robohash.org/{$nickname}" // Default avatar to use for webhook messages
     },
     "ircNickColor": false, // Gives usernames a color in IRC for better readability (on by default)
+    "ircPreventMention": false, // Prevents users of both IRC and Discord from being mentioned in IRC when they speak in Discord (on by default)
     // Makes the bot hide the username prefix for messages that start
     // with one of these characters (commands):
     "commandCharacters": ["!", "."],

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -37,6 +37,7 @@ class Bot {
     this.discordToken = options.discordToken;
     this.commandCharacters = options.commandCharacters || [];
     this.ircNickColor = options.ircNickColor !== false; // default to true
+    this.ircPreventMention = options.ircPreventMention === true; // default: false
     this.channels = _.values(options.channelMapping);
     this.ircStatusNotices = options.ircStatusNotices;
     this.announceSelfJoin = options.announceSelfJoin;
@@ -325,9 +326,16 @@ class Bot {
       const nickname = Bot.getDiscordNicknameOnServer(author, fromGuild);
       let text = this.parseText(message);
       let displayUsername = nickname;
+
+      if (this.ircPreventMention) {
+        // Prevent users of both IRC and Discord from
+        // being mentioned in IRC when they talk in Discord.
+        displayUsername = `${displayUsername.slice(0, 1)}\u200B${displayUsername.slice(1)}`;
+      }
+
       if (this.ircNickColor) {
         const colorIndex = (nickname.charCodeAt(0) + nickname.length) % NICK_COLORS.length;
-        displayUsername = irc.colors.wrap(NICK_COLORS[colorIndex], nickname);
+        displayUsername = irc.colors.wrap(NICK_COLORS[colorIndex], displayUsername);
       }
 
       const patternMap = {

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -336,6 +336,33 @@ describe('Bot', function () {
     }
   );
 
+  it('should break mentions when ircPreventMention is enabled', function () {
+    const newConfig = { ...config, ircPreventMention: true };
+    this.bot = new Bot(newConfig);
+    this.bot.connect();
+
+    const text = 'testmessage';
+    const username = 'otherauthor';
+    const brokenNickname = 'o\u200Btherauthor';
+    const message = {
+      content: text,
+      mentions: { users: [] },
+      channel: {
+        name: 'discord'
+      },
+      author: {
+        username,
+        id: 'not bot id'
+      },
+      guild: this.guild
+    };
+
+    this.bot.sendToIRC(message);
+    // Wrap in colors:
+    const expected = `<\u000304${brokenNickname}\u000f> ${text}`;
+    ClientStub.prototype.say.should.have.been.calledWith('#irc', expected);
+  });
+
   it('should parse text from discord when sending messages', function () {
     const text = '<#1234>';
     const message = {


### PR DESCRIPTION
Supersedes #243. Original credit to @qaisjp, test added, README amended to state it's off by default. Single-character nicks get a random zero-width character appended, but it's not like that affects anything so meh.

Off by default, because some IRC clients were having trouble with it before. It's up to bot owners to make sure this doesn't break any functionality for their users (like maybe for languages where zero-width characters will mess up the language's script? on IRC servers supporting those characters in nicknames).

Fixes #197.