### PR TITLE
Fix avatars not displaying via webhooks

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -578,7 +578,7 @@ class Bot {
       if (permissions) {
         canPingEveryone = permissions.has(discord.Permissions.FLAGS.MENTION_EVERYONE);
       }
-      const avatarURL = this.getDiscordAvatar(author, channel).replace(/\?size=\d{1,}$/,"?size=128");
+      const avatarURL = this.getDiscordAvatar(author, channel).replace(/\?size=\d{1,}$/, '?size=128');
       const username = _.padEnd(author.substring(0, USERNAME_MAX_LENGTH), USERNAME_MIN_LENGTH, '_');
       webhook.client.sendMessage(withMentions, {
         username,

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -433,7 +433,7 @@ class Bot {
 
     // No matching user or more than one => default avatar
     if (users && users.size === 1) {
-      return users.first().user.avatarURL;
+      return users.first().user.avatarURL.replace(/\?size=\d{1,}$/, '?size=128');
     }
 
     // If there isn't a URL format, don't send an avatar at all
@@ -578,7 +578,7 @@ class Bot {
       if (permissions) {
         canPingEveryone = permissions.has(discord.Permissions.FLAGS.MENTION_EVERYONE);
       }
-      const avatarURL = this.getDiscordAvatar(author, channel).replace(/\?size=\d{1,}$/, '?size=128');
+      const avatarURL = this.getDiscordAvatar(author, channel);
       const username = _.padEnd(author.substring(0, USERNAME_MAX_LENGTH), USERNAME_MIN_LENGTH, '_');
       webhook.client.sendMessage(withMentions, {
         username,

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -578,7 +578,7 @@ class Bot {
       if (permissions) {
         canPingEveryone = permissions.has(discord.Permissions.FLAGS.MENTION_EVERYONE);
       }
-      const avatarURL = this.getDiscordAvatar(author, channel);
+      const avatarURL = this.getDiscordAvatar(author, channel).replace(/\?size=\d{1,}$/,"?size=128");
       const username = _.padEnd(author.substring(0, USERNAME_MAX_LENGTH), USERNAME_MIN_LENGTH, '_');
       webhook.client.sendMessage(withMentions, {
         username,

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -1079,7 +1079,7 @@ describe('Bot', function () {
     const userObj = { id: 123, username: 'Nick', avatar: 'avatarURL' };
     const memberObj = { nickname: 'Different' };
     this.addUser(userObj, memberObj);
-    this.bot.getDiscordAvatar('Nick', '#irc').should.equal('/avatars/123/avatarURL.png?size=2048');
+    this.bot.getDiscordAvatar('Nick', '#irc').should.equal('/avatars/123/avatarURL.png?size=128');
   });
 
   it('should find a matching username, case insensitive, when looking for an avatar', function () {
@@ -1089,7 +1089,7 @@ describe('Bot', function () {
     const userObj = { id: 124, username: 'nick', avatar: 'avatarURL' };
     const memberObj = { nickname: 'Different' };
     this.addUser(userObj, memberObj);
-    this.bot.getDiscordAvatar('Nick', '#irc').should.equal('/avatars/124/avatarURL.png?size=2048');
+    this.bot.getDiscordAvatar('Nick', '#irc').should.equal('/avatars/124/avatarURL.png?size=128');
   });
 
   it('should find a matching nickname, case sensitive, when looking for an avatar', function () {
@@ -1099,7 +1099,7 @@ describe('Bot', function () {
     const userObj = { id: 125, username: 'Nick', avatar: 'avatarURL' };
     const memberObj = { nickname: 'Different' };
     this.addUser(userObj, memberObj);
-    this.bot.getDiscordAvatar('Different', '#irc').should.equal('/avatars/125/avatarURL.png?size=2048');
+    this.bot.getDiscordAvatar('Different', '#irc').should.equal('/avatars/125/avatarURL.png?size=128');
   });
 
   it('should not return an avatar with two matching usernames when looking for an avatar', function () {


### PR DESCRIPTION
Avatars that were 2048x2048 would break webhooks displaying avatars, defaulting to 128x128 fixes that.