### PR TITLE
Fix webhooks for users with no avatars

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -438,7 +438,8 @@ class Bot {
 
     // No matching user or more than one => default avatar
     if (users && users.size === 1) {
-      return users.first().user.avatarURL.replace(/\?size=\d{1,}$/, '?size=128');
+      const url = users.first().user.avatarURL;
+      if (url) return url.replace(/\?size=\d{1,}$/, '?size=128');
     }
 
     // If there isn't a URL format, don't send an avatar at all

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -1107,6 +1107,13 @@ describe('Bot', function () {
         this.addUser(userObj, memberObj);
         this.bot.getDiscordAvatar('nickless', '#irc').should.equal('/avatars/124/nickless-avatar.png?size=128');
       });
+
+      it('should handle users without avatars', function () {
+        const userObj = { id: 124, username: 'avatarless' };
+        const memberObj = {};
+        this.addUser(userObj, memberObj);
+        expect(this.bot.getDiscordAvatar('avatarless', '#irc')).to.equal(null);
+      });
     });
 
     context('when matching avatars with fallback URL', function () {
@@ -1133,6 +1140,13 @@ describe('Bot', function () {
         this.bot.getDiscordAvatar('diffUser', '#irc').should.equal('/avatars/125/avatarURL.png?size=128');
         this.bot.getDiscordAvatar('diffNick', '#irc').should.equal('/avatars/124/avatarURL.png?size=128');
         this.bot.getDiscordAvatar('common', '#irc').should.equal('avatarFrom/common');
+      });
+
+      it('should use fallback for users without avatars', function () {
+        const userObj = { id: 124, username: 'avatarless' };
+        const memberObj = {};
+        this.addUser(userObj, memberObj);
+        this.bot.getDiscordAvatar('avatarless', '#irc').should.equal('avatarFrom/avatarless');
       });
     });
   });


### PR DESCRIPTION
Fixes #529. Also copies out some repetitive parts of tests into `beforeEach` hooks, and fixes the test inconsistencies around `this.bot` vs a `const bot` defined in the test (to use custom configs).