### PR TITLE
Add /names command to Discord

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -159,8 +159,17 @@ class Bot {
     });
 
     this.discord.on('message', (message) => {
-      // Ignore bot messages and people leaving/joining
-      this.sendToIRC(message);
+      // Show the IRC channel's /names list when asked for in Discord
+      if (message.content == '/names') {
+        const channelName = `#${message.channel.name}`;
+        const ircChannel = this.channelMapping[message.channel.id] || this.channelMapping[channelName];
+        const ircNames = this.channelUsers[ircChannel].values();
+        const ircNamesArr = new Array(...ircNames);
+        this.sendExactToDiscord(ircChannel, 'Users in ' + ircChannel + "\n> " + ircNamesArr.join(', '));
+      } else {
+        // Ignore bot messages and people leaving/joining
+        this.sendToIRC(message);
+      }
     });
 
     this.ircClient.on('message', this.sendToDiscord.bind(this));


### PR DESCRIPTION
This change adds a `/names` command to Discord so users there can see who is in the associated IRC channel.  The command and its output are only seen in Discord and not carried over to IRC.

Example output:

![Screenshot](https://i.imgur.com/eRljdmk.png)