### PR TITLE
Fix parsing when the same user is mentioned more than once

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -275,9 +275,8 @@ class Bot {
   parseText(message) {
     const text = message.mentions.users.reduce((content, mention) => {
       const displayName = Bot.getDiscordNicknameOnServer(mention, message.guild);
-      return content.replace(`<@${mention.id}>`, `@${displayName}`)
-        .replace(`<@!${mention.id}>`, `@${displayName}`)
-        .replace(`<@&${mention.id}>`, `@${displayName}`);
+      const userMentionRegex = RegExp(`<@(&|!)?${mention.id}>`, 'g');
+      return content.replace(userMentionRegex, `@${displayName}`);
     }, message.content);
 
     return text


### PR DESCRIPTION
Before, the parser would only replace the first instance of a mention for any given user in a message.