### PR TITLE
Added option to replace command prefix with alternative prefix

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -290,8 +290,22 @@ class Bot {
   }
 
   isCommandMessage(message) {
-    return this.commandCharacters.some(prefix => message.startsWith(prefix));
+    return this.commandCharacters.some(prefix => message.startsWith(prefix));	    return this.commandCharacters.some(prefix => 
+      typeof prefix == 'string'
+      ? message.startsWith(prefix)
+      : message.startsWith(prefix[0])
+    );
   }
+
+  getCommandPrefix(message) {
+    if (this.isCommandMessage(message)) {
+      let command = this.commandCharacters.filter(x => typeof x == 'object' && message.startsWith(x[0]))
+      if (command.length > 0) {
+        return command[0]
+      }
+    }
+    return ['', '']
+  } 
 
   ignoredIrcUser(user) {
     return this.ignoreUsers.irc.some(i => i.toLowerCase() === user.toLowerCase());
@@ -360,7 +374,8 @@ class Bot {
           const prelude = Bot.substitutePattern(this.formatCommandPrelude, patternMap);
           this.ircClient.say(ircChannel, prelude);
         }
-        this.ircClient.say(ircChannel, text);
+        let command = this.getCommandPrefix(text)
+        this.ircClient.say(ircChannel, text.replace(command[0], command[1]));
       } else {
         if (text !== '') {
           // Convert formatting


### PR DESCRIPTION
Sometimes you need to change a prefix of a command before sending it to IRC. For example, the IRC channel has bot that has s/ feature implemented. You can't send 's/a/b' from Discord (it's hardcoded to edit feature), instead you can send something like '!s/'. Modify your config:

`"commandCharacters": ["!", ["!s", "s"]]`

and it will replace prefix '!s' with 's' before sending.