### PR TITLE
Drop support for Node <12

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "6"
+          "node": "12"
         }
       }
     ]

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x, 13.x, 14.x]
+        node-version: [12.x, 13.x, 14.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![discord-irc](http://i.imgur.com/oI6iCrf.gif)
 
 ## Installation and usage
-**Note**: discord-irc requires Node.js version 6 or newer, as it depends on [discord.js](https://github.com/hydrabolt/discord.js).
+**Note**: discord-irc requires Node.js version 12 or newer, as it depends on [discord.js](https://github.com/hydrabolt/discord.js).
 Future versions may require newer Node.js versions, though we should support active releases.
 
 Before you can run discord-irc you need to create a configuration file by

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "reactiflux"
   ],
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=12.0.0"
   },
   "main": "dist/index.js",
   "bin": "dist/index.js",


### PR DESCRIPTION
Upcoming updates to discord require us to update our
version of discord.js, which in turn requires Node >=12.