### PR TITLE
Fix winston logging to be primarily single-line

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,23 +1,17 @@
 import winston, { format } from 'winston';
 import { inspect } from 'util';
 
+function simpleInspect(value) {
+  if (typeof value === 'string') return value;
+  return inspect(value, { depth: null });
+}
+
 function formatter(info) {
-  const stringifiedRest = inspect(
-    {
-      ...info,
-      level: undefined,
-      message: undefined,
-      splat: undefined
-    },
-    { depth: null }
-  );
+  const splat = info[Symbol.for('splat')] || [];
+  const stringifiedRest = splat.length > 0 ? ` ${splat.map(simpleInspect).join(' ')}` : '';
 
   const padding = (info.padding && info.padding[info.level]) || '';
-  if (stringifiedRest !== '{}') {
-    return `${info.timestamp} ${info.level}:${padding} ${info.message} ${stringifiedRest}`;
-  }
-
-  return `${info.timestamp} ${info.level}:${padding} ${info.message}`;
+  return `${info.timestamp} ${info.level}:${padding} ${info.message}${stringifiedRest}`;
 }
 
 const logger = winston.createLogger({
@@ -26,7 +20,7 @@ const logger = winston.createLogger({
   format: format.combine(
     format.colorize(),
     format.timestamp(),
-    format.printf(formatter)
+    format.printf(formatter),
   )
 });
 


### PR DESCRIPTION
Fixes ugly lines like:

```
2020-08-09T01:55:45.984Z debug: Connecting to IRC and Discord {
  message: undefined,
  level: undefined,
  timestamp: '2020-08-09T01:55:45.984Z',
  splat: undefined,
  [Symbol(level)]: 'debug'
}
2020-08-09T01:55:46.117Z debug: Received debug event from Discord {
  level: undefined,
  message: undefined,
  timestamp: '2020-08-09T01:55:46.117Z',
  splat: undefined,
  [Symbol(level)]: 'debug',
  [Symbol(splat)]: [ 'Using gateway wss://gateway.discord.gg/?v=6&encoding=json' ]
}
```

To be more like:

```
2020-08-09T01:54:34.452Z debug: Connecting to IRC and Discord
2020-08-09T01:54:34.567Z debug: Received debug event from Discord Using gateway wss://gateway.discord.gg/?v=6&encoding=json
```