### PR TITLE
Add retryLimit of 3 to the Discord client

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -29,7 +29,10 @@ class Bot {
 
     validateChannelMapping(options.channelMapping);
 
-    this.discord = new discord.Client({ autoReconnect: true });
+    this.discord = new discord.Client({
+      autoReconnect: true,
+      retryLimit: 3,
+    });
 
     this.server = options.server;
     this.nickname = options.nickname;


### PR DESCRIPTION
Intended to avoid issues with 500 errors returned
from Discord, as in #461.