### PR TITLE
discord-irc: show when messages are deleted

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -173,6 +173,10 @@ class Bot {
       this.sendToIRC(message);
     });
 
+    this.discord.on('messageDelete', (message) => {
+      this.sendToIRC(message);
+    });
+
     this.ircClient.on('message', this.sendToDiscord.bind(this));
 
     this.ircClient.on('notice', (author, to, text) => {
@@ -281,7 +285,7 @@ class Bot {
       const displayName = Bot.getDiscordNicknameOnServer(mention, message.guild);
       const userMentionRegex = RegExp(`<@(&|!)?${mention.id}>`, 'g');
       return content.replace(userMentionRegex, `@${displayName}`);
-    }, message.content);
+    }, message.deleted ? `<deleted> ${message.content}` : message.content);
 
     return text
       .replace(/\n|\r\n|\r/g, ' ')

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -172,6 +172,29 @@ describe('Bot', function () {
     ClientStub.prototype.say.should.have.been.calledWith('#irc', expected);
   });
 
+  it('should show <deleted> for delete messages', function () {
+    const text = 'testmessage';
+    const newConfig = { ...config, ircNickColor: false };
+    this.setCustomBot(newConfig);
+    const message = {
+      deleted: true,
+      content: text,
+      mentions: { users: [] },
+      channel: {
+        name: 'discord'
+      },
+      author: {
+        username: 'otherauthor',
+        id: 'not bot id'
+      },
+      guild: this.guild
+    };
+
+    this.bot.sendToIRC(message);
+    const expected = `<${message.author.username}> <deleted> ${text}`;
+    ClientStub.prototype.say.should.have.been.calledWith('#irc', expected);
+  });
+
   it('should only use message color defined in config', function () {
     const text = 'testmessage';
     const newConfig = { ...config, ircNickColors: ['orange'] };


### PR DESCRIPTION
This allows for less confusion when someone deletes a message and you try to reply to it now knowing that it was deleted.