### PR TITLE
Log netError events from irc-upd

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -159,7 +159,11 @@ class Bot {
     this.ircClient.on('error', (error) => {
       logger.error('Received error event from IRC', error);
     });
-
+    
+    this.ircClient.on('netError', (error) => {
+      logger.error('Received socket error from IRC', error);
+    });
+    
     this.discord.on('error', (error) => {
       logger.error('Received error event from Discord', error);
     });


### PR DESCRIPTION
Socket errors are logged using the netError event on irc-upd.  Log them, too.