### PR TITLE
Added IRC author avatar URL overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,15 @@ First you need to create a Discord bot user, which you can do by following the i
       // Other patterns that can be used:
       // {$discordChannel} (e.g. #general)
       // {$ircChannel} (e.g. #irc)
-      "webhookAvatarURL": "https://robohash.org/{$nickname}" // Default avatar to use for webhook messages
+      "webhookAvatarURL": "https://robohash.org/{$nickname}", // Default avatar to use for webhook messages
+
+      // Override specific IRC authors to use a set avatar URL for the Discord webhook,
+      // helpful when a user doesn't have a Discord presence or uses a nickname not
+      // supported by IRC
+      "webhookAvatarOverrides": {
+        "ircuser1": "https://imgur.com/example1.png",
+        "ircuser2": "https://imgur.com/example2.png"
+      }
     },
     "ircNickColor": false, // Gives usernames a color in IRC for better readability (on by default)
     "ircNickColors": ['light_blue', 'dark_blue', 'light_red', 'dark_red', 'light_green', 'dark_green', 'magenta', 'light_magenta', 'orange', 'yellow', 'cyan', 'light_cyan'], // Which irc-upd colors to use

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -82,6 +82,11 @@ class Bot {
     // nickname: nickame of IRC message sender
     this.formatWebhookAvatarURL = this.format.webhookAvatarURL;
 
+    // "{$keyName}" => "variableValue"
+    // Use a set avatar URL for specific IRC authors instead
+    // of finding a Discord user match
+    this.formatWebhookAvatarOverrides = this.format.webhookAvatarOverrides || {};
+
     // Keep track of { channel => [list, of, usernames] } for ircStatusNotices
     this.channelUsers = {};
 
@@ -593,7 +598,12 @@ class Bot {
       if (permissions) {
         canPingEveryone = permissions.has(discord.Permissions.FLAGS.MENTION_EVERYONE);
       }
-      const avatarURL = this.getDiscordAvatar(author, channel);
+
+      // Checking for an overriding avatar URL, if provided then use, otherwise
+      // obtain the Discord match
+      const avatarOverrideURL = this.formatWebhookAvatarOverrides[author];
+      const avatarURL = avatarOverrideURL ?? this.getDiscordAvatar(author, channel);
+
       const username = _.padEnd(author.substring(0, USERNAME_MAX_LENGTH), USERNAME_MIN_LENGTH, '_');
       webhook.client.send(withMentions, {
         username,


### PR DESCRIPTION
Sometimes an IRC user may not have a Discord presence or may use a Discord username that isn't supported by IRC but still wants to display something more than the default webhook avatar. I've added the functionality to provide avatar URL overrides for specific authors in order to remedy the problem.

It can be configured in the `config.json` under the `format` options like this:
```json
"webhookAvatarOverrides": {
  "ircuser1": "https://imgur.com/example1.png",
  "ircuser2": "https://imgur.com/example2.png"
}
```

The priority of matching is now like so:
1. Use the avatar override if available for a specific author
2. If not, try and search for a Discord match
3. If nothing is available, use the default webhook avatar

I've complied with the style guide and the linter returned no issues. I'm using this patch on my own IRC/Discord and it has been working great.