### PR TITLE
Fix invalid json syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ First you need to create a Discord bot user, which you can do by following the i
       "webhookAvatarURL": "https://robohash.org/{$nickname}" // Default avatar to use for webhook messages
     },
     "ircNickColor": false, // Gives usernames a color in IRC for better readability (on by default)
-    "ircNickColors": ['light_blue', 'dark_blue', 'light_red', 'dark_red', 'light_green', 'dark_green', 'magenta', 'light_magenta', 'orange', 'yellow', 'cyan', 'light_cyan'], // Which irc-upd colors to use
+    "ircNickColors": ["light_blue", "dark_blue", "light_red", "dark_red", "light_green", "dark_green", "magenta", "light_magenta", "orange", "yellow", "cyan", "light_cyan"], // Which irc-upd colors to use
     "parallelPingFix": true, // Prevents users of both IRC and Discord from being mentioned in IRC when they speak in Discord (off by default)
     // Makes the bot hide the username prefix for messages that start
     // with one of these characters (commands):


### PR DESCRIPTION
Current example file is invalid - the single quotes should be double.

The example file fails with 'The configuration file contains invalid JSON' at line 40 on dist/cli.js - fixed with this change.